### PR TITLE
abstract logger behind pluggable interface

### DIFF
--- a/auto_polling_policy_test.go
+++ b/auto_polling_policy_test.go
@@ -10,7 +10,11 @@ func TestAutoPollingPolicy_GetConfigurationAsync(t *testing.T) {
 
 	fetcher.SetResponse(FetchResponse{Status: Fetched, Body: "test"})
 
-	policy := NewAutoPollingPolicy(fetcher, newConfigStore(NewInMemoryConfigCache()), time.Second*2)
+	policy := NewAutoPollingPolicy(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+		time.Second*2,
+	)
 	defer policy.Close()
 
 	config := policy.GetConfigurationAsync().Get().(string)
@@ -39,7 +43,11 @@ func TestAutoPollingPolicy_GetConfigurationAsync_Fail(t *testing.T) {
 
 	fetcher.SetResponse(FetchResponse{Status: Failure, Body: ""})
 
-	policy := NewAutoPollingPolicy(fetcher, newConfigStore(NewInMemoryConfigCache()), time.Second*2)
+	policy := NewAutoPollingPolicy(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+		time.Second*2,
+	)
 	defer policy.Close()
 
 	config := policy.GetConfigurationAsync().Get().(string)
@@ -55,9 +63,12 @@ func TestAutoPollingPolicy_GetConfigurationAsync_WithListener(t *testing.T) {
 	fetcher.SetResponse(FetchResponse{Status: Fetched, Body: "test"})
 	c := make(chan string, 1)
 	defer close(c)
-	policy := NewAutoPollingPolicyWithChangeListener(fetcher, newConfigStore(NewInMemoryConfigCache()), time.Second*2, func(config string, parser *ConfigParser) {
-		c <- config
-	})
+	policy := NewAutoPollingPolicyWithChangeListener(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+		time.Second*2,
+		func(config string, parser *ConfigParser) { c <- config },
+	)
 	defer policy.Close()
 	config := <-c
 

--- a/config_cache.go
+++ b/config_cache.go
@@ -1,8 +1,6 @@
 package configcat
 
 import (
-	"log"
-	"os"
 	"sync"
 )
 
@@ -21,13 +19,13 @@ type inMemoryConfigCache struct {
 // ConfigStore is used to maintain the cached configuration.
 type ConfigStore struct {
 	cache         ConfigCache
-	logger        *log.Logger
+	logger        Logger
 	inMemoryValue string
 	sync.RWMutex
 }
 
-func newConfigStore(cache ConfigCache) *ConfigStore {
-	return &ConfigStore{cache: cache, logger: log.New(os.Stderr, "[ConfigCat - Config Cache]", log.LstdFlags)}
+func newConfigStore(log Logger, cache ConfigCache) *ConfigStore {
+	return &ConfigStore{cache: cache, logger: log.Prefix("ConfigCat - Config Cache")}
 }
 
 // NewInMemoryConfigCache creates an in-memory cache implementation used to store the fetched configurations.

--- a/config_fetcher.go
+++ b/config_fetcher.go
@@ -2,9 +2,7 @@ package configcat
 
 import (
 	"io/ioutil"
-	"log"
 	"net/http"
-	"os"
 )
 
 // ConfigProvider describes a configuration provider which used to collect the actual configuration.
@@ -16,15 +14,15 @@ type ConfigProvider interface {
 // ConfigFetcher used to fetch the actual configuration over HTTP.
 type ConfigFetcher struct {
 	apiKey, eTag, mode, baseUrl string
-	client             			*http.Client
-	logger             			*log.Logger
+	client                      *http.Client
+	logger                      Logger
 }
 
 func newConfigFetcher(apiKey string, config ClientConfig) *ConfigFetcher {
 	return &ConfigFetcher{apiKey: apiKey,
 		baseUrl: config.BaseUrl,
-		logger: log.New(os.Stderr, "[ConfigCat - Config Fetcher]", log.LstdFlags),
-		client: &http.Client{Timeout: config.HttpTimeout}}
+		logger:  config.Logger.Prefix("ConfigCat - Config Fetcher"),
+		client:  &http.Client{Timeout: config.HttpTimeout}}
 }
 
 // GetConfigurationAsync collects the actual configuration over HTTP.

--- a/lazy_loading_policy.go
+++ b/lazy_loading_policy.go
@@ -1,8 +1,6 @@
 package configcat
 
 import (
-	"log"
-	"os"
 	"sync/atomic"
 	"time"
 )
@@ -15,7 +13,7 @@ type LazyLoadingPolicy struct {
 	initialized     uint32
 	useAsyncRefresh bool
 	lastRefreshTime time.Time
-	logger          *log.Logger
+	logger          Logger
 	fetching        *AsyncResult
 	init            *Async
 }
@@ -39,7 +37,7 @@ func NewLazyLoadingPolicy(
 		useAsyncRefresh: useAsyncRefresh,
 		lastRefreshTime: time.Time{},
 		init:            NewAsync(),
-		logger:          log.New(os.Stderr, "[ConfigCat - Lazy Loading Policy]", log.LstdFlags)}
+		logger:          store.logger.Prefix("ConfigCat - Lazy Loading Policy")}
 }
 
 // GetConfigurationAsync reads the current configuration value.
@@ -54,7 +52,7 @@ func (policy *LazyLoadingPolicy) GetConfigurationAsync() *AsyncResult {
 			return policy.fetching
 		}
 
-		policy.logger.Println("Cache expired, refreshing")
+		policy.logger.Print("Cache expired, refreshing")
 		if initialized {
 			policy.fetching = policy.fetch()
 			if policy.useAsyncRefresh {
@@ -107,6 +105,6 @@ func (policy *LazyLoadingPolicy) fetch() *AsyncResult {
 }
 
 func (policy *LazyLoadingPolicy) readCache() *AsyncResult {
-	policy.logger.Println("Reading from cache")
+	policy.logger.Print("Reading from cache")
 	return AsCompletedAsyncResult(policy.Store.Get())
 }

--- a/lazy_loading_policy_test.go
+++ b/lazy_loading_policy_test.go
@@ -10,7 +10,12 @@ func TestLazyLoadingPolicy_GetConfigurationAsync_DoNotUseAsync(t *testing.T) {
 
 	fetcher.SetResponse(FetchResponse{Status: Fetched, Body: "test"})
 
-	policy := NewLazyLoadingPolicy(fetcher, newConfigStore(NewInMemoryConfigCache()), time.Second*2, false)
+	policy := NewLazyLoadingPolicy(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+		time.Second*2,
+		false,
+	)
 	config := policy.GetConfigurationAsync().Get().(string)
 
 	if config != "test" {
@@ -37,7 +42,12 @@ func TestLazyLoadingPolicy_GetConfigurationAsync_Fail(t *testing.T) {
 
 	fetcher.SetResponse(FetchResponse{Status: Failure, Body: ""})
 
-	policy := NewLazyLoadingPolicy(fetcher, newConfigStore(NewInMemoryConfigCache()), time.Second*2, false)
+	policy := NewLazyLoadingPolicy(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+		time.Second*2,
+		false,
+	)
 	config := policy.GetConfigurationAsync().Get().(string)
 
 	if config != "" {
@@ -50,7 +60,12 @@ func TestLazyLoadingPolicy_GetConfigurationAsync_UseAsync(t *testing.T) {
 
 	fetcher.SetResponse(FetchResponse{Status: Fetched, Body: "test"})
 
-	policy := NewLazyLoadingPolicy(fetcher, newConfigStore(NewInMemoryConfigCache()), time.Second*2, true)
+	policy := NewLazyLoadingPolicy(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+		time.Second*2,
+		true,
+	)
 	config := policy.GetConfigurationAsync().Get().(string)
 
 	if config != "test" {

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,28 @@
+package configcat
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+// Logger defines the interface this library logs with
+type Logger interface {
+	Prefix(string) Logger
+
+	Print(...interface{})
+	Printf(string, ...interface{})
+}
+
+type logger struct {
+	*log.Logger
+}
+
+// DefaultLogger instantiates a default logger backed by the standard library logger
+func DefaultLogger(name string) Logger {
+	return &logger{log.New(os.Stderr, fmt.Sprintf("[%s]", name), log.LstdFlags)}
+}
+
+func (l *logger) Prefix(name string) Logger {
+	return DefaultLogger(name)
+}

--- a/manual_polling_policy_test.go
+++ b/manual_polling_policy_test.go
@@ -7,7 +7,10 @@ import (
 func TestManualPollingPolicy_GetConfigurationAsync(t *testing.T) {
 	fetcher := newFakeConfigProvider()
 	fetcher.SetResponse(FetchResponse{Status: Fetched, Body: "test"})
-	policy := NewManualPollingPolicy(fetcher, newConfigStore(NewInMemoryConfigCache()))
+	policy := NewManualPollingPolicy(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+	)
 	config := policy.GetConfigurationAsync().Get().(string)
 
 	if config != "test" {
@@ -25,7 +28,10 @@ func TestManualPollingPolicy_GetConfigurationAsync(t *testing.T) {
 func TestManualPollingPolicy_GetConfigurationAsync_Fail(t *testing.T) {
 	fetcher := newFakeConfigProvider()
 	fetcher.SetResponse(FetchResponse{Status: Failure, Body: ""})
-	policy := NewManualPollingPolicy(fetcher, newConfigStore(NewInMemoryConfigCache()))
+	policy := NewManualPollingPolicy(
+		fetcher,
+		newConfigStore(DefaultLogger("test"), NewInMemoryConfigCache()),
+	)
 	config := policy.GetConfigurationAsync().Get().(string)
 
 	if config != "" {


### PR DESCRIPTION
It's a bit frustrating to have a library spewing unstructured logs into stderr without having any control over it - this PR changes the client configuration to accept an `interface Logger`, which allows the implementer to spawn child loggers from a parent logger as is standard practice with things like [`zap.Named`](https://godoc.org/go.uber.org/zap#Logger.Named). The default implementation simply spawns new loggers with `log.New`

Happy to make adjustments if needed!