### PR TITLE
Exchanging *User getAttribute to public method.

### DIFF
--- a/rollout_evaluator.go
+++ b/rollout_evaluator.go
@@ -31,7 +31,7 @@ func (evaluator *rolloutEvaluator) evaluate(json interface{}, key string, user *
 			comparisonAttribute, ok := rule["ComparisonAttribute"].(string)
 			comparisonValue, ok := rule["ComparisonValue"].(string)
 			comparator, ok := rule["Comparator"].(float64)
-			userValue := user.getAttribute(comparisonAttribute)
+			userValue := user.GetAttribute(comparisonAttribute)
 
 			if !ok || len(userValue) == 0 {
 				continue

--- a/user.go
+++ b/user.go
@@ -39,7 +39,7 @@ func NewUserWithAdditionalAttributes(identifier string, email string, country st
 	return user
 }
 
-func (user *User) getAttribute(key string) string {
+func (user *User) GetAttribute(key string) string {
 	val := user.attributes[strings.ToLower(key)]
 	if len(val) > 0 {
 		return val


### PR DESCRIPTION
## Description
This PR changes `getAttribute` to a public method.

## Why?
This can be usefull to get information about the `User` you had just initialized. 