### PR TITLE
v6: use less dynamic JSON parsing

### DIFF
--- a/v6/constants.go
+++ b/v6/constants.go
@@ -37,27 +37,3 @@ const (
 	pending   = 0
 	completed = 1
 )
-
-const (
-	entries     = "f"
-	preferences = "p"
-
-	preferencesUrl      = "u"
-	preferencesRedirect = "r"
-
-	settingValue                  = "v"
-	settingType                   = "t"
-	settingRolloutPercentageItems = "p"
-	settingRolloutRules           = "r"
-	settingVariationId            = "i"
-
-	rolloutValue               = "v"
-	rolloutComparisonAttribute = "a"
-	rolloutComparator          = "t"
-	rolloutComparisonValue     = "c"
-	rolloutVariationId         = "i"
-
-	percentageItemValue       = "v"
-	percentageItemPercentage  = "p"
-	percentageItemVariationId = "i"
-)

--- a/v6/rollout_evaluator.go
+++ b/v6/rollout_evaluator.go
@@ -2,6 +2,7 @@ package configcat
 
 import (
 	"crypto/sha1"
+	"encoding/binary"
 	"encoding/hex"
 	"strconv"
 	"strings"
@@ -9,277 +10,298 @@ import (
 	"github.com/blang/semver"
 )
 
+type operator int
+
+const (
+	opOneOf             operator = 0
+	opNotOneOf          operator = 1
+	opContains          operator = 2
+	opNotContains       operator = 3
+	opOneOfSemver       operator = 4
+	opNotOneOfSemver    operator = 5
+	opLessSemver        operator = 6
+	opLessEqSemver      operator = 7
+	opGreaterSemver     operator = 8
+	opGreaterEqSemver   operator = 9
+	opEqNum             operator = 10
+	opNotEqNum          operator = 11
+	opLessNum           operator = 12
+	opLessEqNum         operator = 13
+	opGreaterNum        operator = 14
+	opGreaterEqNum      operator = 15
+	opOneOfSensitive    operator = 16
+	opNotOneOfSensitive operator = 17
+)
+
+var opStrings = []string{
+	opOneOf:             "IS ONE OF",
+	opNotOneOf:          "IS NOT ONE OF",
+	opContains:          "CONTAINS",
+	opNotContains:       "DOES NOT CONTAIN",
+	opOneOfSemver:       "IS ONE OF (SemVer)",
+	opNotOneOfSemver:    "IS NOT ONE OF (SemVer)",
+	opLessSemver:        "< (SemVer)",
+	opLessEqSemver:      "<= (SemVer)",
+	opGreaterSemver:     "> (SemVer)",
+	opGreaterEqSemver:   ">= (SemVer)",
+	opEqNum:             "= (Number)",
+	opNotEqNum:          "<> (Number)",
+	opLessNum:           "< (Number)",
+	opLessEqNum:         "<= (Number)",
+	opGreaterNum:        "> (Number)",
+	opGreaterEqNum:      ">= (Number)",
+	opOneOfSensitive:    "IS ONE OF (Sensitive)",
+	opNotOneOfSensitive: "IS NOT ONE OF (Sensitive)",
+}
+
+func (op operator) String() string {
+	return opStrings[op]
+}
+
 type rolloutEvaluator struct {
-	logger          Logger
-	comparatorTexts []string
+	logger Logger
 }
 
 func newRolloutEvaluator(logger Logger) *rolloutEvaluator {
-	return &rolloutEvaluator{logger: logger,
-		comparatorTexts: []string{
-			"IS ONE OF",
-			"IS NOT ONE OF",
-			"CONTAINS",
-			"DOES NOT CONTAIN",
-			"IS ONE OF (SemVer)",
-			"IS NOT ONE OF (SemVer)",
-			"< (SemVer)",
-			"<= (SemVer)",
-			"> (SemVer)",
-			">= (SemVer)",
-			"= (Number)",
-			"<> (Number)",
-			"< (Number)",
-			"<= (Number)",
-			"> (Number)",
-			">= (Number)",
-			"IS ONE OF (Sensitive)",
-			"IS NOT ONE OF (Sensitive)",
-		}}
+	return &rolloutEvaluator{
+		logger: logger,
+	}
 }
 
-func (evaluator *rolloutEvaluator) evaluate(json interface{}, key string, user *User) (interface{}, string) {
-
-	node, ok := json.(map[string]interface{})
-	if !ok {
-		return nil, ""
-	}
-
+func (evaluator *rolloutEvaluator) evaluate(node *entry, key string, user *User) (interface{}, string) {
 	evaluator.logger.Infof("Evaluating GetValue(%s).", key)
 
-	rolloutRules, rolloutOk := node[settingRolloutRules].([]interface{})
-	percentageRules, percentageOk := node[settingRolloutPercentageItems].([]interface{})
-
 	if user == nil {
-		if (rolloutOk && len(rolloutRules) > 0) || (percentageOk && len(percentageRules) > 0) {
+		if len(node.RolloutRules) > 0 || len(node.PercentageRules) > 0 {
 			evaluator.logger.Warnln("Evaluating GetValue(" + key + "). UserObject missing! You should pass a " +
 				"UserObject to GetValueForUser() in order to make targeting work properly. " +
 				"Read more: https://configcat.com/docs/advanced/user-object.")
 		}
 
-		result := node[settingValue]
+		result := node.Value
 		evaluator.logger.Infof("Returning %v.", result)
-		return result, evaluator.extractVariationId(node[settingVariationId])
+		return result, evaluator.extractVariationId(node.VariationID)
 	}
 
 	evaluator.logger.Infof("User object: %v", user)
 
-	if rolloutOk {
-		for _, r := range rolloutRules {
-			rule, ok := r.(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			comparisonAttribute, ok := rule[rolloutComparisonAttribute].(string)
-			comparisonValue, ok := rule[rolloutComparisonValue].(string)
-			comparator, ok := rule[rolloutComparator].(float64)
-			variationId, ok := rule[rolloutVariationId].(string)
-			userValue := user.GetAttribute(comparisonAttribute)
-			value := rule[rolloutValue]
-
-			if !ok || len(userValue) == 0 {
-				evaluator.logNoMatch(comparisonAttribute, userValue, comparator, comparisonValue)
-				continue
-			}
-
-			switch comparator {
-			//IS ONE OF
-			case 0:
-				separated := strings.Split(comparisonValue, ",")
-				for _, item := range separated {
-					if strings.Contains(strings.TrimSpace(item), userValue) {
-						evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-						return value, variationId
-					}
-				}
-			//IS NOT ONE OF
-			case 1:
-				separated := strings.Split(comparisonValue, ",")
-				found := false
-				for _, item := range separated {
-					if strings.Contains(strings.TrimSpace(item), userValue) {
-						found = true
-					}
-				}
-
-				if !found {
-					evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-					return value, variationId
-				}
-			//CONTAINS
-			case 2:
-				if strings.Contains(userValue, comparisonValue) {
-					evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-					return value, variationId
-				}
-			//DOES NOT CONTAIN
-			case 3:
-				if !strings.Contains(userValue, comparisonValue) {
-					evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-					return value, variationId
-				}
-			//IS ONE OF, IS NOT ONE OF (SemVer)
-			case 4, 5:
-				separated := strings.Split(comparisonValue, ",")
-				userVersion, err := semver.Make(userValue)
-				if err != nil {
-					evaluator.logFormatError(comparisonAttribute, userValue, comparator, comparisonValue, err.Error())
-					continue
-				}
-				matched := false
-				shouldContinue := false
-				for _, item := range separated {
-					cmpItem := strings.TrimSpace(item)
-					if len(cmpItem) == 0 {
-						continue
-					}
-
-					semVer, err := semver.Make(cmpItem)
-					if err != nil {
-						evaluator.logFormatError(comparisonAttribute, userValue, comparator, comparisonValue, err.Error())
-						shouldContinue = true
-						break
-					}
-
-					matched = userVersion.EQ(semVer) || matched
-				}
-
-				if shouldContinue {
-					continue
-				}
-
-				if (matched && comparator == 4) || (!matched && comparator == 5) {
-					evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-					return value, variationId
-				}
-			//LESS THAN, LESS THAN OR EQUALS TO, GREATER THAN, GREATER THAN OR EQUALS TO (SemVer)
-			case 6, 7, 8, 9:
-				userVersion, err := semver.Make(userValue)
-				if err != nil {
-					evaluator.logFormatError(comparisonAttribute, userValue, comparator, comparisonValue, err.Error())
-					continue
-				}
-
-				cmpVersion, err := semver.Make(strings.TrimSpace(comparisonValue))
-				if err != nil {
-					evaluator.logFormatError(comparisonAttribute, userValue, comparator, comparisonValue, err.Error())
-					continue
-				}
-
-				if (comparator == 6 && userVersion.LT(cmpVersion)) ||
-					(comparator == 7 && userVersion.LTE(cmpVersion)) ||
-					(comparator == 8 && userVersion.GT(cmpVersion)) ||
-					(comparator == 9 && userVersion.GTE(cmpVersion)) {
-					evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-					return value, variationId
-				}
-			//LESS THAN, LESS THAN OR EQUALS TO, GREATER THAN, GREATER THAN OR EQUALS TO (SemVer)
-			case 10, 11, 12, 13, 14, 15:
-				userDouble, err := strconv.ParseFloat(strings.Replace(userValue, ",", ".", -1), 64)
-				if err != nil {
-					evaluator.logFormatError(comparisonAttribute, userValue, comparator, comparisonValue, err.Error())
-					continue
-				}
-
-				cmpDouble, err := strconv.ParseFloat(strings.Replace(comparisonValue, ",", ".", -1), 64)
-				if err != nil {
-					evaluator.logFormatError(comparisonAttribute, userValue, comparator, comparisonValue, err.Error())
-					continue
-				}
-
-				if (comparator == 10 && userDouble == cmpDouble) ||
-					(comparator == 11 && userDouble != cmpDouble) ||
-					(comparator == 12 && userDouble < cmpDouble) ||
-					(comparator == 13 && userDouble <= cmpDouble) ||
-					(comparator == 14 && userDouble > cmpDouble) ||
-					(comparator == 15 && userDouble >= cmpDouble) {
-					evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-					return value, variationId
-				}
-			//IS ONE OF (Sensitive)
-			case 16:
-				separated := strings.Split(comparisonValue, ",")
-				sha := sha1.New()
-				sha.Write([]byte(userValue))
-				hash := hex.EncodeToString(sha.Sum(nil))
-				for _, item := range separated {
-					if strings.Contains(strings.TrimSpace(item), hash) {
-						evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-						return value, variationId
-					}
-				}
-			//IS NOT ONE OF (Sensitive)
-			case 17:
-				separated := strings.Split(comparisonValue, ",")
-				found := false
-				sha := sha1.New()
-				sha.Write([]byte(userValue))
-				hash := hex.EncodeToString(sha.Sum(nil))
-				for _, item := range separated {
-					if strings.Contains(strings.TrimSpace(item), hash) {
-						found = true
-					}
-				}
-
-				if !found {
-					evaluator.logMatch(comparisonAttribute, userValue, comparator, comparisonValue, value)
-					return value, variationId
-				}
-			}
-
-			evaluator.logNoMatch(comparisonAttribute, userValue, comparator, comparisonValue)
+	for _, rule := range node.RolloutRules {
+		userValue := user.GetAttribute(rule.ComparisonAttribute)
+		if rule.VariationID == "" || userValue == "" {
+			evaluator.logNoMatch(userValue, rule)
+			continue
 		}
+
+		switch rule.Comparator {
+		case opOneOf:
+			separated := strings.Split(rule.ComparisonValue, ",")
+			for _, item := range separated {
+				if strings.Contains(strings.TrimSpace(item), userValue) {
+					evaluator.logMatch(userValue, rule)
+					return rule.Value, rule.VariationID
+				}
+			}
+		case opNotOneOf:
+			separated := strings.Split(rule.ComparisonValue, ",")
+			found := false
+			for _, item := range separated {
+				if strings.Contains(strings.TrimSpace(item), userValue) {
+					found = true
+				}
+			}
+
+			if !found {
+				evaluator.logMatch(userValue, rule)
+				return rule.Value, rule.VariationID
+			}
+		case opContains:
+			if strings.Contains(userValue, rule.ComparisonValue) {
+				evaluator.logMatch(userValue, rule)
+				return rule.Value, rule.VariationID
+			}
+		case opNotContains:
+			if !strings.Contains(userValue, rule.ComparisonValue) {
+				evaluator.logMatch(userValue, rule)
+				return rule.Value, rule.VariationID
+			}
+		case opOneOfSemver, opNotOneOfSemver:
+			separated := strings.Split(rule.ComparisonValue, ",")
+			userVersion, err := semver.Make(userValue)
+			if err != nil {
+				evaluator.logFormatError(userValue, rule, err)
+				continue
+			}
+			matched := false
+			shouldContinue := false
+			for _, item := range separated {
+				cmpItem := strings.TrimSpace(item)
+				if len(cmpItem) == 0 {
+					continue
+				}
+
+				semVer, err := semver.Make(cmpItem)
+				if err != nil {
+					evaluator.logFormatError(userValue, rule, err)
+					shouldContinue = true
+					break
+				}
+
+				matched = userVersion.EQ(semVer) || matched
+			}
+
+			if shouldContinue {
+				continue
+			}
+			if rule.Comparator == opNotOneOfSemver {
+				matched = !matched
+			}
+			if matched {
+				evaluator.logMatch(userValue, rule)
+				return rule.Value, rule.VariationID
+			}
+		case opLessSemver, opLessEqSemver, opGreaterSemver, opGreaterEqSemver:
+			userVersion, err := semver.Make(userValue)
+			if err != nil {
+				evaluator.logFormatError(userValue, rule, err)
+				continue
+			}
+
+			cmpVersion, err := semver.Make(strings.TrimSpace(rule.ComparisonValue))
+			if err != nil {
+				evaluator.logFormatError(userValue, rule, err)
+				continue
+			}
+			ok := false
+			switch rule.Comparator {
+			case opLessSemver:
+				ok = userVersion.LT(cmpVersion)
+			case opLessEqSemver:
+				ok = userVersion.LTE(cmpVersion)
+			case opGreaterSemver:
+				ok = userVersion.GT(cmpVersion)
+			case opGreaterEqSemver:
+				ok = userVersion.GTE(cmpVersion)
+			}
+			if ok {
+				evaluator.logMatch(userValue, rule)
+				return rule.Value, rule.VariationID
+			}
+		case opEqNum, opNotEqNum, opLessNum, opLessEqNum, opGreaterNum, opGreaterEqNum:
+			userDouble, err := strconv.ParseFloat(strings.Replace(userValue, ",", ".", -1), 64)
+			if err != nil {
+				evaluator.logFormatError(userValue, rule, err)
+				continue
+			}
+
+			cmpDouble, err := strconv.ParseFloat(strings.Replace(rule.ComparisonValue, ",", ".", -1), 64)
+			if err != nil {
+				evaluator.logFormatError(userValue, rule, err)
+				continue
+			}
+
+			ok := false
+			switch rule.Comparator {
+			case opEqNum:
+				ok = userDouble == cmpDouble
+			case opNotEqNum:
+				ok = userDouble != cmpDouble
+			case opLessNum:
+				ok = userDouble < cmpDouble
+			case opLessEqNum:
+				ok = userDouble <= cmpDouble
+			case opGreaterNum:
+				ok = userDouble > cmpDouble
+			case opGreaterEqNum:
+				ok = userDouble >= cmpDouble
+			}
+			if ok {
+				evaluator.logMatch(userValue, rule)
+				return rule.Value, rule.VariationID
+			}
+		case opOneOfSensitive:
+			separated := strings.Split(rule.ComparisonValue, ",")
+			sha := sha1.New()
+			sha.Write([]byte(userValue))
+			hash := hex.EncodeToString(sha.Sum(nil))
+			for _, item := range separated {
+				if strings.Contains(strings.TrimSpace(item), hash) {
+					evaluator.logMatch(userValue, rule)
+					return rule.Value, rule.VariationID
+				}
+			}
+		case opNotOneOfSensitive:
+			separated := strings.Split(rule.ComparisonValue, ",")
+			found := false
+			sha := sha1.New()
+			sha.Write([]byte(userValue))
+			hash := hex.EncodeToString(sha.Sum(nil))
+			for _, item := range separated {
+				if strings.Contains(strings.TrimSpace(item), hash) {
+					found = true
+				}
+			}
+
+			if !found {
+				evaluator.logMatch(userValue, rule)
+				return rule.Value, rule.VariationID
+			}
+		}
+
+		evaluator.logNoMatch(userValue, rule)
 	}
 
-	if percentageOk && len(percentageRules) > 0 {
-		hashCandidate := key + user.identifier
-		sha := sha1.New()
-		sha.Write([]byte(hashCandidate))
-		hash := hex.EncodeToString(sha.Sum(nil))[:7]
-		num, err := strconv.ParseInt(hash, 16, 64)
+	if len(node.PercentageRules) > 0 {
+		sum := sha1.Sum([]byte(key + user.identifier))
+		// Treat the first 4 bytes as a number, then knock
+		// of the last 4 bits. This is equivalent to turning the
+		// entire sum into hex, then decoding the first 7 digits.
+		num := int64(binary.BigEndian.Uint32(sum[:4]))
+		num >>= 4
+
 		scaled := num % 100
-		if err == nil {
-			bucket := int64(0)
-			for _, r := range percentageRules {
-				rule, ok := r.(map[string]interface{})
-				if ok {
-					p, ok := rule[percentageItemPercentage].(float64)
-					if ok {
-						percentage := int64(p)
-						bucket += percentage
-						if scaled < bucket {
-							result := rule[percentageItemValue]
-							evaluator.logger.Infof("Evaluating %% options. Returning %s", result)
-							return result, evaluator.extractVariationId(rule[percentageItemVariationId])
-						}
-					}
-				}
+		bucket := int64(0)
+		for _, rule := range node.PercentageRules {
+			bucket += rule.Percentage
+			if scaled < bucket {
+				result := rule.Value
+				evaluator.logger.Infof("Evaluating %% options. Returning %s", result)
+				return result, evaluator.extractVariationId(rule.VariationID)
 			}
 		}
 	}
 
-	result := node[settingValue]
+	result := node.Value
 	evaluator.logger.Infof("Returning %v.", result)
-	return result, evaluator.extractVariationId(node[settingVariationId])
+	return result, evaluator.extractVariationId(node.VariationID)
 }
 
-func (evaluator *rolloutEvaluator) logMatch(comparisonAttribute string, userValue interface{},
-	comparator float64, comparisonValue string, value interface{}) {
+func (evaluator *rolloutEvaluator) logMatch(userValue interface{}, rule rolloutRule) {
 	evaluator.logger.Infof("Evaluating rule: [%s:%s] [%s] [%s] => match, returning: %v",
-		comparisonAttribute, userValue, evaluator.comparatorTexts[int(comparator)], comparisonValue, value)
+		rule.ComparisonAttribute,
+		userValue,
+		rule.Comparator,
+		rule.ComparisonValue,
+		rule.Value,
+	)
 }
 
-func (evaluator *rolloutEvaluator) logNoMatch(comparisonAttribute string, userValue interface{},
-	comparator float64, comparisonValue string) {
+func (evaluator *rolloutEvaluator) logNoMatch(userValue interface{}, rule rolloutRule) {
 	evaluator.logger.Infof("Evaluating rule: [%s:%s] [%s] [%s] => no match",
-		comparisonAttribute, userValue, evaluator.comparatorTexts[int(comparator)], comparisonValue)
+		rule.ComparisonAttribute,
+		userValue,
+		rule.Comparator,
+		rule.Value,
+	)
 }
 
-func (evaluator *rolloutEvaluator) logFormatError(comparisonAttribute string, userValue interface{},
-	comparator float64, comparisonValue string, error string) {
-	evaluator.logger.Infof("Evaluating rule: [%s:%s] [%s] [%s] => SKIP rule. Validation error: %s",
-		comparisonAttribute, userValue, evaluator.comparatorTexts[int(comparator)], comparisonValue, error)
+func (evaluator *rolloutEvaluator) logFormatError(userValue interface{}, rule rolloutRule, err error) {
+	evaluator.logger.Infof("Evaluating rule: [%s:%s] [%s] [%s] => SKIP rule. Validation error: %v",
+		rule.ComparisonAttribute,
+		userValue,
+		rule.Comparator,
+		rule.Value,
+		err,
+	)
 }
 
 func (evaluator *rolloutEvaluator) extractVariationId(variationId interface{}) string {


### PR DESCRIPTION
The Go encoding/json package makes it easy to define types
that represent the shape of the expected data, which lets the
JSON parser do most of the heavy lifting around checking for
type compatibility.

This PR changes the code to follow this approach, arguably
making the code cleaner and  easier to follow.

Also define an `operator` type which is idiomatic in Go for representing
a known set of constants, rather than using literal numbers in the codee.