### PR TITLE
v6: return pointer fron newConfigRefresher

### DIFF
--- a/v6/auto_polling_policy.go
+++ b/v6/auto_polling_policy.go
@@ -7,7 +7,7 @@ import (
 
 // autoPollingPolicy describes a refreshPolicy which polls the latest configuration over HTTP and updates the local cache repeatedly.
 type autoPollingPolicy struct {
-	refresher        configRefresher
+	refresher        *configRefresher
 	autoPollInterval time.Duration
 	init             *async
 	initialized      uint32

--- a/v6/lazy_loading_policy.go
+++ b/v6/lazy_loading_policy.go
@@ -7,7 +7,7 @@ import (
 
 // lazyLoadingPolicy describes a refreshPolicy which uses an expiring cache to maintain the internally stored configuration.
 type lazyLoadingPolicy struct {
-	refresher       configRefresher
+	refresher       *configRefresher
 	cacheInterval   time.Duration
 	isFetching      uint32
 	initialized     uint32

--- a/v6/manual_polling_policy.go
+++ b/v6/manual_polling_policy.go
@@ -2,7 +2,7 @@ package configcat
 
 // manualPollingPolicy describes a refreshPolicy which fetches the latest configuration over HTTP every time when a get configuration is called.
 type manualPollingPolicy struct {
-	refresher configRefresher
+	refresher *configRefresher
 }
 
 type manualPollConfig struct {


### PR DESCRIPTION
Also avoid embedding the mutex (it's not idiomatic to do that,
as the mutex is generally considered to be a private
implementation detail of the type), and position it in the
struct so that it's more clear which fields it's guarding.

Also acquire the read lock inside `getLastCachedConfig`.