### PR TITLE
v6: restore missed logging messages

### DIFF
--- a/v6/auto_polling_policy.go
+++ b/v6/auto_polling_policy.go
@@ -46,7 +46,7 @@ func AutoPollWithChangeListener(
 type autoPollingPolicy struct {
 	fetcher      *configFetcher
 	changeNotify func()
-	logger       Logger
+	logger       *leveledLogger
 	// mu guards the closing of the closed channel.
 	mu     sync.Mutex
 	closed chan struct{}
@@ -63,7 +63,6 @@ func newAutoPollingPolicy(
 		changeNotify: config.changeNotify,
 		logger:       rconfig.logger,
 	}
-	policy.logger.Debugf("Auto polling started with %+v interval.", config.interval)
 	policy.fetcher.startRefresh()
 	go policy.poller(config.interval)
 	return policy
@@ -90,7 +89,6 @@ func (policy *autoPollingPolicy) poller(interval time.Duration) {
 	for {
 		select {
 		case <-policy.closed:
-			policy.logger.Debugf("Auto polling stopped.")
 			return
 		case <-ticker.C:
 			policy.refresh(ctx)

--- a/v6/config_parser.go
+++ b/v6/config_parser.go
@@ -18,7 +18,7 @@ type config struct {
 	jsonBody  string
 	etag      string
 	root      *rootNode
-	evaluate  func(logger Logger, key string, user *User) (interface{}, string, error)
+	evaluate  func(logger *leveledLogger, key string, user *User) (interface{}, string, error)
 	allKeys   []string
 	keyValues map[string]keyValue
 	fetchTime time.Time
@@ -62,7 +62,7 @@ func (conf *config) getAllKeys() []string {
 	return conf.allKeys
 }
 
-func (conf *config) getValueAndVariationId(logger Logger, key string, user *User) (interface{}, string, error) {
+func (conf *config) getValueAndVariationId(logger *leveledLogger, key string, user *User) (interface{}, string, error) {
 	if conf == nil {
 		return nil, "", fmt.Errorf("no configuration available")
 	}

--- a/v6/config_parser_test.go
+++ b/v6/config_parser_test.go
@@ -8,7 +8,7 @@ import (
 func TestConfigParser_Parse(t *testing.T) {
 	jsonBody := `{ "f": { "keyDouble": { "v": 120.121238476, "p": [], "r": [], "i":"" }}}`
 	config := mustParseConfig(jsonBody)
-	val, _, err := config.getValueAndVariationId(DefaultLogger(LogLevelWarn), "keyDouble", nil)
+	val, _, err := config.getValueAndVariationId(testLeveledLogger(t), "keyDouble", nil)
 
 	if err != nil || val != 120.121238476 {
 		t.Error("Expecting 120.121238476 as interface")
@@ -27,7 +27,7 @@ func TestConfigParser_BadJson(t *testing.T) {
 func TestConfigParser_WrongKey(t *testing.T) {
 	jsonBody := `{ "keyDouble": { "Value": 120.121238476, "SettingType": 0, "RolloutPercentageItems": [], "RolloutRules": [] }}`
 	config := mustParseConfig(jsonBody)
-	_, _, err := config.getValueAndVariationId(DefaultLogger(LogLevelWarn), "wrongKey", nil)
+	_, _, err := config.getValueAndVariationId(testLeveledLogger(t), "wrongKey", nil)
 	if err == nil {
 		t.Error("Expecting key not found error")
 	}
@@ -38,7 +38,7 @@ func TestConfigParser_WrongKey(t *testing.T) {
 func TestConfigParser_EmptyNode(t *testing.T) {
 	jsonBody := `{ "keyDouble": { }}`
 	config := mustParseConfig(jsonBody)
-	_, _, err := config.getValueAndVariationId(DefaultLogger(LogLevelWarn), "keyDouble", nil)
+	_, _, err := config.getValueAndVariationId(testLeveledLogger(t), "keyDouble", nil)
 	if err == nil {
 		t.Error("Expecting key not found error")
 	}

--- a/v6/configcat_client_test.go
+++ b/v6/configcat_client_test.go
@@ -331,7 +331,7 @@ func TestClient_GetWithStandardURLAndShouldRedirect(t *testing.T) {
 	}))
 	transport.enqueue(200, marshalJSON(rootNodeWithKeyValue("key", "value")))
 	client := NewCustomClient("fakeKey", ClientConfig{
-		Logger:    testLogger{t},
+		Logger:    newTestLogger(t, LogLevelDebug),
 		Transport: transport,
 	})
 	result := client.GetValue("key", "default")
@@ -359,7 +359,7 @@ func TestClient_GetWithStandardURLAndNoRedirect(t *testing.T) {
 		},
 	}))
 	client := NewCustomClient("fakeKey", ClientConfig{
-		Logger:    testLogger{t},
+		Logger:    newTestLogger(t, LogLevelDebug),
 		Transport: transport,
 	})
 	result := client.GetValue("key", "default")

--- a/v6/configserver_test.go
+++ b/v6/configserver_test.go
@@ -50,7 +50,7 @@ func newConfigServerWithKey(t *testing.T, sdkKey string) *configServer {
 func (srv *configServer) config() ClientConfig {
 	return ClientConfig{
 		BaseUrl: srv.srv.URL,
-		Logger:  testLogger{srv.t},
+		Logger:  newTestLogger(srv.t, LogLevelDebug),
 	}
 }
 
@@ -150,10 +150,25 @@ func marshalJSON(x interface{}) string {
 	return string(data)
 }
 
+func testLeveledLogger(t testing.TB) *leveledLogger {
+	return &leveledLogger{
+		level:  LogLevelDebug,
+		Logger: newTestLogger(t, LogLevelDebug),
+	}
+}
+
 // testLogger implements the Logger interface by logging to the test.T
 // instance.
 type testLogger struct {
-	t *testing.T
+	t     testing.TB
+	level LogLevel
+}
+
+func newTestLogger(t testing.TB, level LogLevel) Logger {
+	return &testLogger{
+		t:     t,
+		level: level,
+	}
 }
 
 func (log testLogger) Debugf(format string, args ...interface{}) {

--- a/v6/user.go
+++ b/v6/user.go
@@ -16,29 +16,19 @@ func NewUserWithAdditionalAttributes(identifier string, email string, country st
 	user := &User{identifier: identifier, attributes: map[string]string{}}
 	user.attributes["Identifier"] = identifier
 
-	if len(email) > 0 {
+	if email != "" {
 		user.attributes["Email"] = email
 	}
-
-	if len(country) > 0 {
+	if country != "" {
 		user.attributes["Country"] = country
 	}
-
-	if len(custom) > 0 {
-		for k, v := range custom {
-			user.attributes[k] = v
-		}
+	for k, v := range custom {
+		user.attributes[k] = v
 	}
-
 	return user
 }
 
 // GetAttribute retrieves a user attribute identified by a key.
 func (user *User) GetAttribute(key string) string {
-	val := user.attributes[key]
-	if len(val) > 0 {
-		return val
-	}
-
-	return ""
+	return user.attributes[key]
 }


### PR DESCRIPTION
v6: restore missed logging messages

There were a few informational and warning messages that had
been missed in the transition. We reinstate those, but they
made things slower again, so we add  wrapper type
that can be used to inspect the logging level before logging,
which avoids the allocations from calling the log methods.

Also change the log level type to be an alias to the logrus
level type so that we can define the `LoggerWithLevel` interface
without needing to use two level types in the public API.
This should be backwardly compatible except for some
highly unlikely (and easily fixable) use cases, such as `fmt.Sprint(level)`
formatting differently because `logrus.Level` implements a `String` method.

We also use a more realistic benchmark that actually
exercises the rules by passing a User value in.

Change from before the evaluator preprocessing to this PR:

```
name        old time/op    new time/op    delta
GetValue-8     590ns ± 9%     283ns ± 5%  -52.10%  (p=0.008 n=5+5)

name        old alloc/op   new alloc/op   delta
GetValue-8      320B ± 0%       96B ± 0%  -70.00%  (p=0.008 n=5+5)

name        old allocs/op  new allocs/op  delta
GetValue-8      10.0 ± 0%       2.0 ± 0%  -80.00%  (p=0.008 n=5+5)
```

Change from the most recent master to this PR:

```
name        old time/op    new time/op    delta
GetValue-8     307ns ± 3%     283ns ± 5%   -8.04%  (p=0.008 n=5+5)

name        old alloc/op   new alloc/op   delta
GetValue-8      112B ± 0%       96B ± 0%  -14.29%  (p=0.008 n=5+5)

name        old allocs/op  new allocs/op  delta
GetValue-8      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```