### PR TITLE
v6: more benchmarks

### DIFF
--- a/v6/benchmark_test.go
+++ b/v6/benchmark_test.go
@@ -1,0 +1,129 @@
+package configcat
+
+import (
+	"strconv"
+	"testing"
+)
+
+func BenchmarkGet(b *testing.B) {
+	benchmarks := []struct {
+		benchName string
+		node      *rootNode
+		rule      string
+		makeUser  func() *User
+		want      string
+	}{{
+		benchName: "one-of",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"rule": {
+					VariationID: "607147d5",
+					Value:       "no-match",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Email",
+						ComparisonValue:     "a@configcat.com, b@configcat.com",
+						Comparator:          opOneOf,
+						VariationID:         "385d9803",
+						Value:               "email-match",
+					}, {
+						ComparisonAttribute: "Country",
+						ComparisonValue:     "United",
+						Comparator:          opNotOneOf,
+						VariationID:         "385d9803",
+						Value:               "country-match",
+					}},
+				},
+			},
+		},
+		rule: "rule",
+		makeUser: func() *User {
+			return NewUserWithAdditionalAttributes("unknown-identifier", "x@configcat.com", "United", nil)
+		},
+		want: "no-match",
+	}, {
+		benchName: "less-than-with-int",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"rule": {
+					VariationID: "607147d5",
+					Value:       "no-match",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Age",
+						ComparisonValue:     "21",
+						Comparator:          opLessNum,
+						VariationID:         "385d9803",
+						Value:               "age-match",
+					}},
+				},
+			},
+		},
+		rule: "rule",
+		makeUser: func() *User {
+			age := 18
+			return NewUserWithAdditionalAttributes("unknown-identifier", "x@configcat.com", "United", map[string]string{
+				"Age": strconv.FormatInt(int64(age), 10),
+			})
+		},
+		want: "age-match",
+	}, {
+		benchName: "with-percentage",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"bool30TrueAdvancedRules": {
+					VariationID: "607147d5",
+					Value:       "no-match",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Email",
+						ComparisonValue:     "a@configcat.com, b@configcat.com",
+						Comparator:          opOneOf,
+						VariationID:         "385d9803",
+						Value:               "email-match",
+					}, {
+						ComparisonAttribute: "Country",
+						ComparisonValue:     "United",
+						Comparator:          opNotOneOf,
+						VariationID:         "385d9803",
+						Value:               "country-match",
+					}},
+					PercentageRules: []percentageRule{{
+						VariationID: "607147d5",
+						Value:       "low-percent",
+						Percentage:  30,
+					}, {
+						VariationID: "385d9803",
+						Value:       "high-percent",
+						Percentage:  70,
+					}},
+				},
+			},
+		},
+		rule: "bool30TrueAdvancedRules",
+		makeUser: func() *User {
+			return NewUserWithAdditionalAttributes("unknown-identifier", "x@configcat.com", "United", nil)
+		},
+		want: "high-percent",
+	}}
+	for _, bench := range benchmarks {
+		b.Run(bench.benchName, func(b *testing.B) {
+			b.ReportAllocs()
+			srv := newConfigServer(b)
+			srv.setResponseJSON(bench.node)
+			cfg := srv.config()
+			cfg.Mode = ManualPoll()
+			cfg.Logger = DefaultLogger(LogLevelError)
+			cfg.StaticLogLevel = true
+
+			client := NewCustomClient(srv.sdkKey(), cfg)
+			client.Refresh()
+			defer client.Close()
+			val := client.GetValueForUser(bench.rule, "", bench.makeUser()).(string)
+			if val != bench.want {
+				b.Fatalf("unexpected result %#v", val)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = client.GetValueForUser(bench.rule, "", bench.makeUser()).(string)
+			}
+		})
+	}
+}

--- a/v6/configserver_test.go
+++ b/v6/configserver_test.go
@@ -16,7 +16,7 @@ import (
 type configServer struct {
 	srv *httptest.Server
 	key string
-	t   *testing.T
+	t   testing.TB
 
 	mu        sync.Mutex
 	resp      *configResponse
@@ -29,13 +29,13 @@ type configResponse struct {
 	sleep  time.Duration
 }
 
-func newConfigServer(t *testing.T) *configServer {
+func newConfigServer(t testing.TB) *configServer {
 	var buf [8]byte
 	rand.Read(buf[:])
 	return newConfigServerWithKey(t, fmt.Sprintf("fake-%x", buf[:]))
 }
 
-func newConfigServerWithKey(t *testing.T, sdkKey string) *configServer {
+func newConfigServerWithKey(t testing.TB, sdkKey string) *configServer {
 	srv := &configServer{
 		t: t,
 	}

--- a/v6/rollout_integration_test.go
+++ b/v6/rollout_integration_test.go
@@ -24,27 +24,6 @@ type integrationTest struct {
 	kind     int
 }
 
-func BenchmarkGetValue(b *testing.B) {
-	b.ReportAllocs()
-	logger := DefaultLogger(LogLevelError)
-	client := NewCustomClient(integrationTests[0].sdkKey, ClientConfig{
-		Logger:         logger,
-		Mode:           ManualPoll(),
-		StaticLogLevel: true,
-	})
-	client.Refresh()
-	defer client.Close()
-	user := NewUser("unknown-identifier")
-	val := client.GetValueForUser("bool30TrueAdvancedRules", "default", user)
-	if val != false {
-		b.Fatalf("unexpected result %#v", val)
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		client.GetValueForUser("bool30TrueAdvancedRules", "default", user)
-	}
-}
-
 var integrationTests = []integrationTest{{
 	sdkKey:   "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A",
 	fileName: "testmatrix.csv",


### PR DESCRIPTION
Add some more benchmarks so that we
can compare costs with v7.

Note that the `Get/with-percentage` benchmark
is exactly the same as the old `GetValue` benchmark
except that it also includes creation of the user value
as part of the benchmark.

```
name                      time/op
Get/one-of-8              314ns ± 0%
Get/less-than-with-int-8  403ns ± 2%
Get/with-percentage-8     635ns ±14%

name                      alloc/op
Get/one-of-8               360B ± 0%
Get/less-than-with-int-8   360B ± 0%
Get/with-percentage-8      456B ± 0%

name                      allocs/op
Get/one-of-8               3.00 ± 0%
Get/less-than-with-int-8   3.00 ± 0%
Get/with-percentage-8      5.00 ± 0%
```