### PR TITLE
v7: reflection-based API

### DIFF
--- a/v7/benchmark_test.go
+++ b/v7/benchmark_test.go
@@ -1,0 +1,135 @@
+package configcat
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkGet(b *testing.B) {
+	benchmarks := []struct {
+		benchName string
+		node      *rootNode
+		rule      string
+		makeUser  func() User
+		want      string
+	}{{
+		benchName: "one-of",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"rule": {
+					VariationID: "607147d5",
+					Value:       "no-match",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Email",
+						ComparisonValue:     "a@configcat.com, b@configcat.com",
+						Comparator:          opOneOf,
+						VariationID:         "385d9803",
+						Value:               "email-match",
+					}, {
+						ComparisonAttribute: "Country",
+						ComparisonValue:     "United",
+						Comparator:          opNotOneOf,
+						VariationID:         "385d9803",
+						Value:               "country-match",
+					}},
+				},
+			},
+		},
+		rule: "rule",
+		makeUser: func() User {
+			return &UserValue{
+				Identifier: "unknown-identifier",
+				Email:      "x@configcat.com",
+				Country:    "United",
+			}
+		},
+		want: "no-match",
+	}, {
+		benchName: "less-than-with-int",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"rule": {
+					VariationID: "607147d5",
+					Value:       "no-match",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Age",
+						ComparisonValue:     "21",
+						Comparator:          opLessNum,
+						VariationID:         "385d9803",
+						Value:               "age-match",
+					}},
+				},
+			},
+		},
+		rule: "rule",
+		makeUser: func() User {
+			return &struct {
+				Age int
+			}{18}
+		},
+		want: "age-match",
+	}, {
+		benchName: "with-percentage",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"bool30TrueAdvancedRules": {
+					VariationID: "607147d5",
+					Value:       "no-match",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Email",
+						ComparisonValue:     "a@configcat.com, b@configcat.com",
+						Comparator:          opOneOf,
+						VariationID:         "385d9803",
+						Value:               "email-match",
+					}, {
+						ComparisonAttribute: "Country",
+						ComparisonValue:     "United",
+						Comparator:          opNotOneOf,
+						VariationID:         "385d9803",
+						Value:               "country-match",
+					}},
+					PercentageRules: []percentageRule{{
+						VariationID: "607147d5",
+						Value:       "low-percent",
+						Percentage:  30,
+					}, {
+						VariationID: "385d9803",
+						Value:       "high-percent",
+						Percentage:  70,
+					}},
+				},
+			},
+		},
+		rule: "bool30TrueAdvancedRules",
+		makeUser: func() User {
+			return &UserValue{
+				Identifier: "unknown-identifier",
+				Email:      "x@configcat.com",
+				Country:    "United",
+			}
+		},
+		want: "high-percent",
+	}}
+	for _, bench := range benchmarks {
+		b.Run(bench.benchName, func(b *testing.B) {
+			b.ReportAllocs()
+			srv := newConfigServer(b)
+			srv.setResponseJSON(bench.node)
+			cfg := srv.config()
+			cfg.RefreshMode = Manual
+			cfg.Logger = DefaultLogger(LogLevelError)
+
+			client := NewCustomClient(cfg)
+			client.Refresh(context.Background())
+			defer client.Close()
+			val := client.String(bench.rule, "", bench.makeUser())
+			if val != bench.want {
+				b.Fatalf("unexpected result %#v", val)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				client.String(bench.rule, "", bench.makeUser())
+			}
+		})
+	}
+}

--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -181,7 +181,7 @@ func (client *Client) Close() {
 // In Lazy refresh mode, this can block indefinitely while the configuration
 // is fetched. Use RefreshIfOlder explicitly if explicit control of timeouts
 // is needed.
-func (client *Client) Bool(key string, defaultValue bool, user *User) bool {
+func (client *Client) Bool(key string, defaultValue bool, user User) bool {
 	if v, ok := client.getValue(key, user).(bool); ok {
 		return v
 	}
@@ -189,7 +189,7 @@ func (client *Client) Bool(key string, defaultValue bool, user *User) bool {
 }
 
 // Int is like Bool except for int-typed (whole number) feature flags.
-func (client *Client) Int(key string, defaultValue int, user *User) int {
+func (client *Client) Int(key string, defaultValue int, user User) int {
 	if v, ok := client.getValue(key, user).(float64); ok {
 		// TODO log error?
 		return int(v)
@@ -198,7 +198,7 @@ func (client *Client) Int(key string, defaultValue int, user *User) int {
 }
 
 // Int is like Bool except for float-typed (decimal number) feature flags.
-func (client *Client) Float(key string, defaultValue float64, user *User) float64 {
+func (client *Client) Float(key string, defaultValue float64, user User) float64 {
 	if v, ok := client.getValue(key, user).(float64); ok {
 		// TODO log error?
 		return v
@@ -207,7 +207,7 @@ func (client *Client) Float(key string, defaultValue float64, user *User) float6
 }
 
 // Int is like Bool except for string-typed (text) feature flags.
-func (client *Client) String(key string, defaultValue string, user *User) string {
+func (client *Client) String(key string, defaultValue string, user User) string {
 	if v, ok := client.getValue(key, user).(string); ok {
 		// TODO log error?
 		return v
@@ -215,23 +215,25 @@ func (client *Client) String(key string, defaultValue string, user *User) string
 	return defaultValue
 }
 
-// GetValue returns a value synchronously as interface{} from the configuration identified by the given key.
-func (client *Client) getValue(key string, user *User) interface{} {
-	value, _, _ := client.current().getValueAndVariationID(client.logger, key, user)
-	// TODO log error?
+// getValue returns a value synchronously as interface{} from the configuration identified by the given key.
+func (client *Client) getValue(key string, user User) interface{} {
+	value, _, err := client.current().getValueAndVariationID(client.logger, key, user)
+	if err != nil {
+		client.logger.Errorf("error getting value: %v", err)
+	}
 	return value
 }
 
 // VariationID returns the variation ID that will be used for the given key
 // with the given optional user. If none is found, the empty string is returned.
-func (client *Client) VariationID(key string, user *User) string {
+func (client *Client) VariationID(key string, user User) string {
 	_, variationID, _ := client.current().getValueAndVariationID(client.logger, key, user)
 	return variationID
 }
 
 // VariationIDs returns all  variation IDs in the current configuration
 // that apply to the given optional user.
-func (client *Client) VariationIDs(user *User) []string {
+func (client *Client) VariationIDs(user User) []string {
 	conf := client.current()
 	keys := conf.keys()
 	ids := make([]string, 0, len(keys))

--- a/v7/configcat_client_test.go
+++ b/v7/configcat_client_test.go
@@ -84,7 +84,7 @@ func TestClient_Get(t *testing.T) {
 	c.Assert(result, qt.Equals, 3213.0)
 }
 
-func TestClient_Get_IsOneOf_Uses_Contains_Semantics(t *testing.T) {
+func TestClient_Get_IsOneOf_Does_Not_Use_Contains_Semantics(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(&rootNode{
@@ -104,15 +104,15 @@ func TestClient_Get_IsOneOf_Uses_Contains_Semantics(t *testing.T) {
 	})
 	client.Refresh(context.Background())
 
-	matchingUser := NewUser("mple")
+	matchingUser := &UserValue{Identifier: "mple"}
 	result := client.Bool("feature", false, matchingUser)
-	c.Assert(result, qt.IsTrue)
+	c.Assert(result, qt.IsFalse)
 
-	matchingUser = NewUser("foobar")
+	matchingUser = &UserValue{Identifier: "foobar"}
 	result = client.Bool("feature", false, matchingUser)
 	c.Assert(result, qt.IsTrue)
 
-	matchingUser = NewUser("nonexisting")
+	matchingUser = &UserValue{Identifier: "nonexisting"}
 	result = client.Bool("feature", false, matchingUser)
 	c.Assert(result, qt.IsFalse)
 }

--- a/v7/configserver_test.go
+++ b/v7/configserver_test.go
@@ -16,7 +16,7 @@ import (
 type configServer struct {
 	srv *httptest.Server
 	key string
-	t   *testing.T
+	t   testing.TB
 
 	mu        sync.Mutex
 	resp      *configResponse
@@ -29,13 +29,13 @@ type configResponse struct {
 	sleep  time.Duration
 }
 
-func newConfigServer(t *testing.T) *configServer {
+func newConfigServer(t testing.TB) *configServer {
 	var buf [8]byte
 	rand.Read(buf[:])
 	return newConfigServerWithKey(t, fmt.Sprintf("fake-%x", buf[:]))
 }
 
-func newConfigServerWithKey(t *testing.T, sdkKey string) *configServer {
+func newConfigServerWithKey(t testing.TB, sdkKey string) *configServer {
 	srv := &configServer{
 		t: t,
 	}

--- a/v7/eval_test.go
+++ b/v7/eval_test.go
@@ -1,0 +1,640 @@
+package configcat
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestOpOneOfWithStringValue(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+
+	for _, s := range []string{"", "hello", "x"} {
+		for _, user := range stringVariants(s) {
+			c.Run(fmt.Sprintf("%#v-%v", user, s), func(c *qt.C) {
+				for _, test := range stringOneOfTests(s) {
+					test.run(c, ectx, user)
+				}
+			})
+		}
+	}
+}
+
+type typedString string
+
+type customString struct {
+	val string
+}
+
+func (s customString) String() string {
+	return s.val
+}
+
+type customPtrString struct {
+	val string
+}
+
+func (s *customPtrString) String() string {
+	return s.val
+}
+
+func TestOpOneOfWithNumericValue(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+
+	for _, tv := range []interface{}{int8(0), int16(0), int32(0), int64(0), uint8(0), uint16(0), uint32(0), uint64(0), float32(0), float64(0)} {
+		t := reflect.TypeOf(tv)
+		lo, hi := numLimits(t)
+		xnames := []string{
+			"lowest",
+			"highest",
+			"zero",
+			"NaN",
+			"+Infinity",
+			"-Infinity",
+		}
+		for i, x := range []float64{lo, hi, 0, math.NaN(), math.Inf(1), math.Inf(-1)} {
+			if (math.IsNaN(x) || math.IsInf(x, 0)) && t.Kind() != reflect.Float64 && t.Kind() != reflect.Float32 {
+				// Can't put non-finite values in a non-float field.
+				continue
+			}
+			c.Run(fmt.Sprintf("%s-%v", t, xnames[i]), func(c *qt.C) {
+				v := reflect.New(t).Elem()
+				setValueFromFloat(v, x)
+				user := newTestStruct(v)
+				for _, test := range numericOneOfTests(x) {
+					test.run(c, ectx, user)
+				}
+			})
+		}
+	}
+}
+
+func TestOpCmpNumWithNumericValue(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+
+	for _, op := range []operator{
+		opEqNum,
+		opLessNum,
+		opLessEqNum,
+		opGreaterNum,
+		opGreaterEqNum,
+	} {
+		for _, tv := range []interface{}{int8(0), int16(0), int32(0), int64(0), uint8(0), uint16(0), uint32(0), uint64(0), float32(0), float64(0)} {
+			t := reflect.TypeOf(tv)
+			lo, hi := numLimits(t)
+			xnames := []string{
+				"lowest",
+				"highest",
+				"zero",
+				"NaN",
+				"+Infinity",
+				"-Infinity",
+			}
+			for i, x := range []float64{lo, hi, 0, math.NaN(), math.Inf(1), math.Inf(-1)} {
+				if (math.IsNaN(x) || math.IsInf(x, 0)) && t.Kind() != reflect.Float64 && t.Kind() != reflect.Float32 {
+					// Can't put non-finite values in a non-float field.
+					continue
+				}
+				c.Run(fmt.Sprintf("%v-%s-%v", op, t, xnames[i]), func(c *qt.C) {
+					v := reflect.New(t).Elem()
+					setValueFromFloat(v, x)
+					user := newTestStruct(v)
+					for _, test := range numericCmpNumTests(x, op, cmpFunc(op)) {
+						test.run(c, ectx, user)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestOpCmpNumWithInvalidCmpVal(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+
+	for _, op := range []operator{
+		opEqNum,
+		opLessNum,
+		opLessEqNum,
+		opGreaterNum,
+		opGreaterEqNum,
+	} {
+		for _, tv := range []interface{}{int8(0), int16(0), int32(0), int64(0), uint8(0), uint16(0), uint32(0), uint64(0), float32(0), float64(0)} {
+			(&opTest{
+				testName: fmt.Sprintf("%T-%v", tv, op),
+				op:       op,
+				cmpVal:   "badnum",
+				want:     false,
+			}).run(c, ectx, newTestStruct(reflect.ValueOf(tv)))
+		}
+	}
+}
+
+func TestOpCmpNumWithStringValue(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+
+	tests := []struct {
+		s      string
+		op     operator
+		cmpVal string
+		want   bool
+	}{
+		{"1.5", opEqNum, "1.5", true},
+		{"1.5", opEqNum, "1.6", false},
+		{"", opEqNum, "0", false},
+		{"1.5", opNotEqNum, "1.5", false},
+		{"1.5", opLessNum, "1.6", true},
+		{"1.6", opLessNum, "1.5", false},
+		{"1.5", opLessNum, "1.5", false},
+		{"1.5", opLessEqNum, "1.5", true},
+		{"1.5", opLessEqNum, "1.6", true},
+		{"1.6", opLessEqNum, "1.5", false},
+		// Invalid numbers always compare false.
+		{"bad", opEqNum, "1.5", false},
+		{"bad", opNotEqNum, "1.5", false},
+		{"bad", opLessNum, "1.5", false},
+		{"bad", opLessEqNum, "1.5", false},
+		{"bad", opGreaterNum, "1.5", false},
+		{"bad", opGreaterEqNum, "1.5", false},
+		// NaN always compares false.
+		{"NaN", opEqNum, "1.5", false},
+		{"NaN", opNotEqNum, "1.5", false},
+		{"NaN", opLessNum, "1.5", false},
+		{"NaN", opLessEqNum, "1.5", false},
+		{"NaN", opGreaterNum, "1.5", false},
+		{"NaN", opGreaterEqNum, "1.5", false},
+	}
+	for _, test := range tests {
+		s := test.s
+		for _, user := range stringVariants(test.s) {
+			(&opTest{
+				testName: fmt.Sprintf("%#v-%q-%v-%q", user, s, test.op, test.cmpVal),
+				op:       test.op,
+				cmpVal:   test.cmpVal,
+				want:     test.want,
+			}).run(c, ectx, user)
+		}
+	}
+}
+
+func TestOpSemverWithNonStringDoesNotMatch(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+	// A non-string semver never satisfies a semver condition.
+	user := &struct {
+		X int
+	}{1}
+	for _, op := range []operator{
+		opOneOfSemver,
+		opNotOneOfSemver,
+		opLessSemver,
+		opLessEqSemver,
+		opGreaterSemver,
+		opGreaterEqSemver,
+	} {
+		(&opTest{
+			testName: op.String(),
+			op:       op,
+			cmpVal:   "1.0.0",
+			want:     false,
+		}).run(c, ectx, user)
+	}
+}
+
+func TestOpSemverWithString(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+
+	tests := []struct {
+		s      string
+		op     operator
+		cmpVal string
+		want   bool
+	}{
+		{"1.5.0", opOneOfSemver, "1.5.0", true},
+		{"1.5.0", opOneOfSemver, "1.5.0,1.5.1", true},
+		{"1.5.0", opOneOfSemver, "1.5.1,1.5.2", false},
+		{"1.5.0", opOneOfSemver, "   1.5.0  ,1.5.2   ", true},
+		{"1.5.0", opNotOneOfSemver, "1.5.0", false},
+		{"1.5.0", opNotOneOfSemver, "1.5.0,1.5.1", false},
+		{"1.5.0", opNotOneOfSemver, "1.5.1,1.5.2", true},
+		{"1.5.0", opNotOneOfSemver, "   1.5.0  ,1.5.2   ", false},
+		{"1.4.0", opLessSemver, "1.5.0", true},
+		{"1.4.0", opLessSemver, " 1.5.0 ", true},
+		{"1.4.0", opLessSemver, "1.4.0", false},
+		{"1.4.0", opLessSemver, "1.3.0", false},
+		{"1.4.0", opGreaterSemver, "1.5.0", false},
+		{"1.4.0", opGreaterSemver, "1.4.0", false},
+		{"1.4.0", opGreaterSemver, "1.3.0", true},
+		{"1.4.0", opLessEqSemver, "1.5.0", true},
+		{"1.4.0", opLessEqSemver, "1.4.0", true},
+		{"1.4.0", opLessEqSemver, "1.3.0", false},
+		{"1.4.0", opGreaterEqSemver, "1.5.0", false},
+		{"1.4.0", opGreaterEqSemver, "1.4.0", true},
+		{"1.4.0", opGreaterEqSemver, "1.3.0", true},
+	}
+	for _, test := range tests {
+		s := test.s
+		for _, user := range stringVariants(s) {
+			(&opTest{
+				testName: fmt.Sprintf("%#v-%q-%v-%q", user, s, test.op, test.cmpVal),
+				op:       test.op,
+				cmpVal:   test.cmpVal,
+				want:     test.want,
+			}).run(c, ectx, user)
+		}
+	}
+}
+
+func TestNoUser(t *testing.T) {
+	c := qt.New(t)
+	ectx := newEvalTestContext(c)
+	(&opTest{
+		testName: "nil-interface",
+		op:       opOneOf,
+		cmpVal:   "foo",
+		want:     false,
+	}).run(c, ectx, nil)
+	(&opTest{
+		testName: "nil-struct",
+		op:       opOneOf,
+		cmpVal:   "foo",
+		want:     false,
+	}).run(c, ectx, (*struct{ X string })(nil))
+}
+
+func TestNonPointerUserStruct(t *testing.T) {
+	c := qt.New(t)
+	c.Skip("this is an awkward case that we need to think about")
+	ectx := newEvalTestContext(c)
+	(&opTest{
+		testName: "nil-struct",
+		op:       opOneOf,
+		cmpVal:   "foo",
+		want:     false,
+	}).run(c, ectx, struct{ X string }{})
+}
+
+func stringVariants(s string) []User {
+	vs := []interface{}{
+		s,
+		typedString(s),
+		customString{s},
+		&customPtrString{s},
+		customPtrString{s},
+		[]byte(s),
+	}
+	var us []User
+	for _, v := range vs {
+		us = append(us, newTestStruct(reflect.ValueOf(v)))
+	}
+	us = append(us,
+		&UserValue{
+			Custom: map[string]string{
+				"X": s,
+			},
+		},
+		&attributeGetter{
+			v: s,
+		})
+	return us
+}
+
+type attributeGetter struct {
+	v string
+}
+
+func (g *attributeGetter) GetAttribute(attr string) string {
+	if attr == "X" {
+		return g.v
+	}
+	return ""
+}
+
+// opTest represents a test for a particular operator with respect to some
+// user field value.
+type opTest struct {
+	testName string
+	// op is the operator to test.
+	op operator
+	// cmpVal is the argument to the operator.
+	cmpVal string
+	// want holds the expected result of the test.
+	want bool
+}
+
+func (test *opTest) run(c *qt.C, ectx *evalTestContext, user User) {
+	c.Run(test.testName, func(c *qt.C) {
+		ectx.logger.t = c
+		c.Logf("operator %v; cmpVal %v; want %v", test.op, test.cmpVal, test.want)
+		ectx.srv.setResponseJSON(&rootNode{
+			Entries: map[string]*entry{
+				"key": {
+					VariationID: "testFallback",
+					Value:       "false",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "X",
+						ComparisonValue:     test.cmpVal,
+						Comparator:          test.op,
+						VariationID:         "test",
+						Value:               "true",
+					}},
+				},
+			},
+		})
+		ectx.client.Refresh(context.Background())
+		want := "false"
+		if test.want {
+			want = "true"
+		}
+		c.Check(ectx.client.String("key", "", user), qt.Equals, want, qt.Commentf("user: %#v", user))
+	})
+}
+
+// stringOneOfTests returns a set of tests for opOneOf and
+// opNotOneOf given a user value of s.
+func stringOneOfTests(s string) []opTest {
+	other := "x"
+	if other == s {
+		other = "y"
+	}
+	tests := []opTest{{
+		testName: "exact-value",
+		op:       opOneOf,
+		cmpVal:   s,
+		want:     true,
+	}, {
+		testName: "with-extra-value",
+		op:       opOneOf,
+		cmpVal:   s + "," + other,
+		want:     true,
+	}, {
+		testName: "with-appended-value",
+		op:       opOneOf,
+		cmpVal:   s + "x",
+		want:     false,
+	}, {
+		testName: "empty-string",
+		op:       opOneOf,
+		cmpVal:   "",
+		want:     false,
+	}}
+	// Add tests for opNotOneOf.
+	for _, test := range tests {
+		tests = append(tests, opTest{
+			testName: "not(" + test.testName + ")",
+			op:       opNotOneOf,
+			cmpVal:   test.cmpVal,
+			want:     !test.want,
+		})
+	}
+	// When the comparison string is empty, all comparisons are false.
+	if s == "" {
+		for i := range tests {
+			tests[i].want = false
+		}
+	}
+	return tests
+}
+
+// numericCmpNumTests returns a set of tests for the
+// comparison operator op given a User field with value x.
+// cmp reports the result of the comparison operator.
+func numericCmpNumTests(x float64, op operator, cmp func(a, b float64) bool) []opTest {
+	if math.IsNaN(x) {
+		return []opTest{{
+			testName: "is-nan",
+			op:       op,
+			cmpVal:   "NaN",
+			want:     false,
+		}, {
+			testName: "non-nan",
+			op:       op,
+			cmpVal:   "0",
+			want:     false,
+		}}
+	}
+
+	tests := []opTest{{
+		testName: "exact-value",
+		op:       op,
+		cmpVal:   fmt.Sprint(x),
+		want:     cmp(x, x),
+	}}
+	if !math.IsInf(x, 0) {
+		tests = append(tests, []opTest{{
+			testName: "small-increment",
+			op:       op,
+			cmpVal:   fmt.Sprint(addSomethingSmall(x)),
+			want:     cmp(x, addSomethingSmall(x)),
+		}, {
+			testName: "small-decrement",
+			op:       op,
+			cmpVal:   fmt.Sprint(subSomethingSmall(x)),
+			want:     cmp(x, subSomethingSmall(x)),
+		}, {
+			testName: "double",
+			op:       op,
+			cmpVal:   fmt.Sprint(x * 2),
+			want:     cmp(x, x*2),
+		}, {
+			testName: "half",
+			op:       op,
+			cmpVal:   fmt.Sprint(x / 2),
+			want:     cmp(x, x/2),
+		}}...)
+	}
+	if x != 0 {
+		tests = append(tests, opTest{
+			testName: "negate",
+			op:       op,
+			cmpVal:   fmt.Sprint(-x),
+			want:     cmp(x, -x),
+		})
+	}
+	for _, test := range tests {
+		// commas are treated as decimal points.
+		if strings.Contains(test.cmpVal, ".") {
+			tests = append(tests, opTest{
+				testName: test.testName + "-commas",
+				op:       op,
+				cmpVal:   strings.ReplaceAll(test.cmpVal, ".", ","),
+				want:     test.want,
+			})
+		}
+	}
+	return tests
+}
+
+// numericOneOfTests returns a set of tests for opOneOf and opNotOneOf given
+// a User field with value x.
+func numericOneOfTests(x float64) []opTest {
+	var tests []opTest
+	if math.IsNaN(x) {
+		tests = []opTest{{
+			testName: "exact-value-as-float",
+			op:       opOneOf,
+			cmpVal:   fmt.Sprint(x),
+			want:     false,
+		}}
+	} else {
+		tests = []opTest{{
+			testName: "exact-value-as-float",
+			op:       opOneOf,
+			cmpVal:   fmt.Sprint(x),
+			want:     true,
+		}}
+		if !math.IsInf(x, 0) {
+			tests = append(tests, opTest{
+				testName: "small-increment",
+				op:       opOneOf,
+				cmpVal:   fmt.Sprint(addSomethingSmall(x)),
+				want:     false,
+			})
+		}
+	}
+	other := 0.0
+	if x == other {
+		other = 1
+	}
+	for _, test := range tests {
+		tests = append(tests, opTest{
+			testName: test.testName + "-with-extra-elem",
+			op:       opOneOf,
+			cmpVal:   fmt.Sprint(other) + "," + test.cmpVal,
+			want:     test.want,
+		}, opTest{
+			testName: test.testName + "-with-space",
+			op:       opOneOf,
+			cmpVal:   " " + test.cmpVal + " ",
+			want:     test.want,
+		})
+	}
+	// Add tests for opNotOneOf too.
+	for _, test := range tests {
+		tests = append(tests, opTest{
+			testName: "not(" + test.testName + ")",
+			op:       opNotOneOf,
+			cmpVal:   test.cmpVal,
+			want:     !test.want,
+		})
+	}
+	return tests
+}
+
+func addSomethingSmall(x float64) float64 {
+	xinc := x
+	for inc := 0.492342353422345; ; inc *= 2 {
+		if xinc != x {
+			return xinc
+		}
+		xinc = x + inc
+	}
+}
+
+func subSomethingSmall(x float64) float64 {
+	xinc := x
+	for inc := -0.492342353422345; ; inc *= 2 {
+		if xinc != x {
+			return xinc
+		}
+		xinc = x + inc
+	}
+}
+
+type evalTestContext struct {
+	srv    *configServer
+	client *Client
+	logger *testLogger
+}
+
+func newEvalTestContext(c *qt.C) *evalTestContext {
+	var ectx evalTestContext
+	ectx.srv = newConfigServer(c)
+	cfg := ectx.srv.config()
+	cfg.RefreshMode = Manual
+	ectx.logger = newTestLogger(c, LogLevelDebug).(*testLogger)
+	cfg.Logger = ectx.logger
+	ectx.client = NewCustomClient(cfg)
+	return &ectx
+}
+
+// newTestStruct returns a struct with field X holding v.
+func newTestStruct(v reflect.Value) User {
+	userv := reflect.New(reflect.StructOf([]reflect.StructField{{
+		Name: "X",
+		Type: v.Type(),
+	}}))
+	userv.Elem().Field(0).Set(v)
+	return userv.Interface()
+}
+
+// numLimits returns the numeric limits of the given numeric type.
+// We don't return the actual limits for 64 bit types because
+// there are too many unresolvable issues at those values.
+func numLimits(t reflect.Type) (float64, float64) {
+	switch t.Kind() {
+	case reflect.Float64:
+		return -1e30, 1e30
+	case reflect.Float32:
+		return -math.MaxFloat32, math.MaxFloat32
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		bits := uint(8 * t.Size())
+		if bits == 64 {
+			// Cop out of rounding errors.
+			bits = 52
+		}
+		lim := int64(1 << (bits - 1))
+		return float64(-lim), float64(lim - 1)
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		bits := uint(8 * t.Size())
+		if bits == 64 {
+			// Cop out of rounding errors.
+			bits = 52
+		}
+		return 0, float64(int64(1<<bits) - 1)
+	default:
+		panic(fmt.Errorf("unhandled type %v", t))
+	}
+}
+
+func setValueFromFloat(v reflect.Value, f float64) {
+	switch v.Kind() {
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(int64(f))
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(uint64(f))
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(f)
+	default:
+		panic(fmt.Errorf("unhandled type %v", v.Type()))
+	}
+}
+
+func cmpFunc(op operator) func(a, b float64) bool {
+	return func(a, b float64) bool {
+		switch op {
+		case opEqNum:
+			return a == b
+		case opLessNum:
+			return a < b
+		case opLessEqNum:
+			return a <= b
+		case opGreaterNum:
+			return a > b
+		case opGreaterEqNum:
+			return a >= b
+		default:
+			panic(fmt.Errorf("unknown comparison operator %v", op))
+		}
+	}
+}

--- a/v7/rollout_integration_test.go
+++ b/v7/rollout_integration_test.go
@@ -4,11 +4,14 @@ import (
 	"bufio"
 	"context"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -21,27 +24,6 @@ type integrationTest struct {
 	sdkKey   string
 	fileName string
 	kind     int
-}
-
-func BenchmarkGetValue(b *testing.B) {
-	b.ReportAllocs()
-	logger := DefaultLogger(LogLevelError)
-	client := NewCustomClient(Config{
-		SDKKey:      integrationTests[0].sdkKey,
-		Logger:      logger,
-		RefreshMode: Manual,
-	})
-	client.Refresh(context.Background())
-	defer client.Close()
-	user := NewUser("unknown-identifier")
-	val := client.Bool("bool30TrueAdvancedRules", true, user)
-	if val != false {
-		b.Fatalf("unexpected result %#v", val)
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		client.Bool("bool30TrueAdvancedRules", true, user)
-	}
 }
 
 var integrationTests = []integrationTest{{
@@ -83,11 +65,15 @@ func (test integrationTest) runTest(t *testing.T) {
 		srv.setResponse(configResponse{body: contentForIntegrationTestKey(test.sdkKey)})
 		cfg = srv.config()
 	}
-	cfg.Logger = newTestLogger(t, LogLevelError)
+	tlogger := newTestLogger(t, LogLevelDebug).(*testLogger)
+	cfg.Logger = tlogger
 	cfg.SDKKey = test.sdkKey
 	client := NewCustomClient(cfg)
-	client.Refresh(context.Background())
 	defer client.Close()
+	err := client.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("cannot refresh: %v", err)
+	}
 
 	file, fileErr := os.Open(filepath.Join("../resources", test.fileName))
 	if fileErr != nil {
@@ -111,53 +97,60 @@ func (test integrationTest) runTest(t *testing.T) {
 			log.Fatal(err)
 		}
 		lineNumber++
-		var user *User
-		if line[0] != "##null##" {
-			identifier := line[0]
-			email := nullStr(line[1])
-			country := nullStr(line[2])
-			custom := map[string]string{}
-			if s := nullStr(line[3]); s != "" {
-				custom[customKey] = line[3]
-			}
-			user = NewUserWithAdditionalAttributes(identifier, email, country, custom)
-		}
-
-		for i, settingKey := range settingKeys {
-			var val interface{}
-			switch test.kind {
-			case valueKind:
-				val = client.getValue(settingKey, user)
-			case variationKind:
-				val = client.VariationID(settingKey, user)
-			default:
-				t.Fatalf("unexpected kind %v", test.kind)
-			}
-			expected := line[i+4]
-			var expectedVal interface{}
-			var err error
-			switch val := val.(type) {
-			case bool:
-				expectedVal, err = strconv.ParseBool(expected)
-			case int:
-				expectedVal, err = strconv.Atoi(expected)
-			case float64:
-				expectedVal, err = strconv.ParseFloat(expected, 64)
-			case string:
-				expectedVal = expected
-			default:
-				t.Fatalf("Value was not handled %#v", val)
-			}
-			if err != nil {
-				t.Fatalf("cannot parse expected value %q as %T: %v", expected, val, err)
-			}
-			if val != expectedVal {
-				t.Errorf("unexpected result for key %s at %s:%d; got %#v want %#v", settingKey, file.Name(), lineNumber, val, expectedVal)
-				for key, val := range user.attributes {
-					t.Logf("user %s: %q", key, val)
+		t.Run(fmt.Sprintf("line-%d", lineNumber), func(t *testing.T) {
+			var user User
+			if line[0] != "##null##" {
+				userVal := &UserValue{
+					Identifier: nullStr(line[0]),
+					Email:      nullStr(line[1]),
+					Country:    nullStr(line[2]),
 				}
+				if s := nullStr(line[3]); s != "" {
+					userVal.Custom = map[string]string{
+						customKey: s,
+					}
+				}
+				user = userVal
 			}
-		}
+			t.Logf("user %#v", user)
+
+			for i, settingKey := range settingKeys {
+				t.Run(fmt.Sprintf("key-%s", settingKey), func(t *testing.T) {
+					t.Logf("rule:\n%s", describeRules(client.fetcher.current(), settingKey))
+					tlogger.t = t
+					var val interface{}
+					switch test.kind {
+					case valueKind:
+						val = client.getValue(settingKey, user)
+					case variationKind:
+						val = client.VariationID(settingKey, user)
+					default:
+						t.Fatalf("unexpected kind %v", test.kind)
+					}
+					expected := line[i+4]
+					var expectedVal interface{}
+					var err error
+					switch val := val.(type) {
+					case bool:
+						expectedVal, err = strconv.ParseBool(expected)
+					case int:
+						expectedVal, err = strconv.Atoi(expected)
+					case float64:
+						expectedVal, err = strconv.ParseFloat(expected, 64)
+					case string:
+						expectedVal = expected
+					default:
+						t.Fatalf("value was not handled %T %#v; expected %q", val, val, expected)
+					}
+					if err != nil {
+						t.Fatalf("cannot parse expected value %q as %T: %v", expected, val, err)
+					}
+					if val != expectedVal {
+						t.Errorf("unexpected result for key %s at %s:%d; got %#v want %#v", settingKey, file.Name(), lineNumber, val, expectedVal)
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -166,4 +159,41 @@ func nullStr(s string) string {
 		return ""
 	}
 	return s
+}
+
+func describeRules(cfg *config, specificKey string) string {
+	if cfg == nil {
+		return "no config"
+	}
+
+	var buf strings.Builder
+	printf := func(f string, a ...interface{}) {
+		fmt.Fprintf(&buf, f, a...)
+	}
+	printResult := func(value interface{}, variationID string) {
+		printf("\t→ %T %#v; variation %q\n", value, value, variationID)
+	}
+	keys := make([]string, 0, len(cfg.root.Entries))
+	for key := range cfg.root.Entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if specificKey != "" && key != specificKey {
+			continue
+		}
+		entry := cfg.root.Entries[key]
+		printf("%q\n", key)
+		for _, rule := range entry.RolloutRules {
+			printf("\t: user.%s %v %q\n", rule.ComparisonAttribute, rule.Comparator, rule.ComparisonValue)
+			printResult(rule.Value, rule.VariationID)
+		}
+		for _, rule := range entry.PercentageRules {
+			printf("\t: %d%%\n", rule.Percentage)
+			printResult(rule.Value, rule.VariationID)
+		}
+		printf("\t: default\n")
+		printResult(entry.Value, entry.VariationID)
+	}
+	return buf.String()
 }

--- a/v7/visiblefields.go
+++ b/v7/visiblefields.go
@@ -1,0 +1,91 @@
+package configcat
+
+import (
+	"reflect"
+	"sort"
+)
+
+// visibleFields returns all the visible fields in t, which must be a
+// struct type. A field is defined as visible if it's accessible
+// directly with a FieldByName call. The returned fields include fields
+// inside anonymous struct members and unexported fields. They follow
+// the same order found in the struct, with anonymous fields followed
+// immediately by their promoted fields.
+//
+// For each element e of the returned slice, the corresponding field
+// can be retrieved from a value v of type t by calling v.FieldByIndex(e.Index).
+//
+// If this makes it into the standard library, we could remove it...
+// https://github.com/golang/go/issues/42782
+func visibleFields(t reflect.Type) []reflect.StructField {
+	byName := make(map[string]reflect.StructField)
+	addFields(t, byName, nil)
+	fields := make(fieldsByIndex, 0, len(byName))
+	for _, f := range byName {
+		if f.Name != "" {
+			fields = append(fields, f)
+		}
+	}
+	sort.Sort(fields)
+	return fields
+}
+
+func addFields(t reflect.Type, byName map[string]reflect.StructField, index []int) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		index := append(index, i)
+		var add bool
+		old, ok := byName[f.Name]
+		switch {
+		case ok && len(old.Index) == len(index):
+			// Fields with the same name at the same depth
+			// cancel one another out. Set the field name
+			// to empty to signify that has happened.
+			old.Name = ""
+			byName[f.Name] = old
+			add = false
+		case ok:
+			// Fields at less depth win.
+			add = len(index) < len(old.Index)
+		default:
+			// The field did not previously exist.
+			add = true
+		}
+		if add {
+			// copy the index so that it's not overwritten
+			// by the other appends.
+			f.Index = append([]int(nil), index...)
+			byName[f.Name] = f
+		}
+		if f.Anonymous {
+			if f.Type.Kind() == reflect.Ptr {
+				f.Type = f.Type.Elem()
+			}
+			if f.Type.Kind() == reflect.Struct {
+				addFields(f.Type, byName, index)
+			}
+		}
+	}
+}
+
+type fieldsByIndex []reflect.StructField
+
+func (f fieldsByIndex) Len() int {
+	return len(f)
+}
+
+func (f fieldsByIndex) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+func (f fieldsByIndex) Less(i, j int) bool {
+	indexi, indexj := f[i].Index, f[j].Index
+	for len(indexi) != 0 && len(indexj) != 0 {
+		ii, ij := indexi[0], indexj[0]
+		if ii != ij {
+			return ii < ij
+		}
+		indexi, indexj = indexi[1:], indexj[1:]
+	}
+	return len(indexi) < len(indexj)
+}


### PR DESCRIPTION
This allows a user-defined User object to be passed in,
making it easier to use an arbitrary domain object for the
user data and avoiding the need to convert to and from the
intermediate string format for numeric comparisons.

Although the specification is simple (allow any numeric type or any
type with a String method), that allows for quite a number of possible
combinations, so the eval code becomes somewhat more complex.
It might be better to restrict the number of possible types
(for example, by only allowing `int` and `float64` and `string`)
or use floating point comparisons always for the numeric operators,
which might reduce the amount of code required.
I can't quite decide!

Benchmarks compared with v6:

```
name                      old time/op    new time/op    delta
Get/one-of-8                 339ns ± 4%     167ns ±18%  -50.73%  (p=0.008 n=5+5)
Get/less-than-with-int-8     436ns ± 5%     106ns ± 6%  -75.76%  (p=0.008 n=5+5)
Get/with-percentage-8        678ns ±16%     469ns ± 2%  -30.86%  (p=0.008 n=5+5)

name                      old alloc/op   new alloc/op   delta
Get/one-of-8                  360B ± 0%       64B ± 0%  -82.22%  (p=0.008 n=5+5)
Get/less-than-with-int-8      360B ± 0%        8B ± 0%  -97.78%  (p=0.008 n=5+5)
Get/with-percentage-8         456B ± 0%      136B ± 0%  -70.18%  (p=0.008 n=5+5)

name                      old allocs/op  new allocs/op  delta
Get/one-of-8                  3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.008 n=5+5)
Get/less-than-with-int-8      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.008 n=5+5)
Get/with-percentage-8         5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.008 n=5+5)
```
