### PR TITLE
v7: add generic value-get methods

### DIFF
--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -200,6 +200,13 @@ func (client *Client) String(key string, defaultValue string, user User) string 
 	return String(key, defaultValue).Get(client.Snapshot(user))
 }
 
+// Get returns a feature flag value regardless of type. If there is no
+// value found, it returns nil; otherwise the returned value
+// has one of the dynamic types bool, int, float64, or string.
+func (client *Client) Get(key string, user User) interface{} {
+	return client.Snapshot(user).Get(key)
+}
+
 func (client *Client) Snapshot(user User) *Snapshot {
 	if client.needGetCheck {
 		switch client.cfg.RefreshMode {

--- a/v7/flag.go
+++ b/v7/flag.go
@@ -51,8 +51,8 @@ type IntFlag struct {
 }
 
 func (f IntFlag) Get(snap *Snapshot) int {
-	if v, ok := snap.value(f.id, f.key).(float64); ok {
-		return int(v)
+	if v, ok := snap.value(f.id, f.key).(int); ok {
+		return v
 	}
 	return f.defaultValue
 }

--- a/v7/lazy_loading_policy_test.go
+++ b/v7/lazy_loading_policy_test.go
@@ -12,7 +12,7 @@ import (
 func TestLazyLoadingPolicy_NoAsync(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
-	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1"))
+	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1", stringEntry))
 
 	cfg := srv.config()
 	cfg.RefreshMode = Lazy
@@ -23,7 +23,7 @@ func TestLazyLoadingPolicy_NoAsync(t *testing.T) {
 	c.Assert(client.String("key", "", nil), qt.Equals, "value1")
 
 	srv.setResponse(configResponse{
-		body:  marshalJSON(rootNodeWithKeyValue("key", "value2")),
+		body:  marshalJSON(rootNodeWithKeyValue("key", "value2", stringEntry)),
 		sleep: 40 * time.Millisecond,
 	})
 	c.Assert(client.String("key", "", nil), qt.Equals, "value1")
@@ -52,7 +52,7 @@ func TestLazyLoadingPolicy_FetchFail(t *testing.T) {
 func TestLazyLoadingPolicy_Async(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
-	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1"))
+	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1", stringEntry))
 
 	cfg := srv.config()
 	cfg.RefreshMode = Lazy
@@ -67,7 +67,7 @@ func TestLazyLoadingPolicy_Async(t *testing.T) {
 	c.Assert(client.String("key", "", nil), qt.Equals, "value1")
 
 	srv.setResponse(configResponse{
-		body:  marshalJSON(rootNodeWithKeyValue("key", "value2")),
+		body:  marshalJSON(rootNodeWithKeyValue("key", "value2", stringEntry)),
 		sleep: 40 * time.Millisecond,
 	})
 	c.Assert(client.String("key", "", nil), qt.Equals, "value1")

--- a/v7/snapshot.go
+++ b/v7/snapshot.go
@@ -68,6 +68,19 @@ func (snap *Snapshot) valueAndVariationID(id keyID, key string) (interface{}, st
 	return eval(snap.logger, snap.user)
 }
 
+// Get returns a feature flag value regardless of type. If there is no
+// value found, it returns nil; otherwise the returned value
+// has one of the dynamic types bool, int, float64, or string.
+//
+// To use obtain the value of a typed feature flag, use
+// one of the typed feature flag functions. For example:
+//
+//	someFlag := configcat.Bool("someFlag", false)
+// 	value := someFlag.Get(snap)
+func (snap *Snapshot) Get(key string) interface{} {
+	return snap.value(idForKey(key, true), key)
+}
+
 // KeyValueForVariationID returns the key and value that
 // are associated with the given variation ID. If the
 // variation ID isn't found, it returns "", nil.


### PR DESCRIPTION
We can use the settingType (`t`) value in the config
to know what kind of value should be returned.