### PR TITLE
v7: avoid copying mutex when copying configuration

### DIFF
--- a/v7/config_parser.go
+++ b/v7/config_parser.go
@@ -16,10 +16,12 @@ func (p *parseError) Error() string {
 }
 
 type config struct {
-	jsonBody   []byte
-	etag       string
-	root       *rootNode
-	evaluators sync.Map // reflect.Type -> map[string]entryEvalFunc
+	jsonBody []byte
+	etag     string
+	root     *rootNode
+	// Note: this is a pointer because the configuration
+	// can be copied (with the withFetchTime method).
+	evaluators *sync.Map // reflect.Type -> map[string]entryEvalFunc
 	allKeys    []string
 	keyValues  map[string]keyValue
 	fetchTime  time.Time
@@ -33,12 +35,13 @@ func parseConfig(jsonBody []byte, etag string, fetchTime time.Time) (*config, er
 	fixupRootNodeValues(&root)
 
 	return &config{
-		jsonBody:  jsonBody,
-		root:      &root,
-		keyValues: keyValuesForRootNode(&root),
-		allKeys:   keysForRootNode(&root),
-		etag:      etag,
-		fetchTime: fetchTime,
+		jsonBody:   jsonBody,
+		root:       &root,
+		evaluators: new(sync.Map),
+		keyValues:  keyValuesForRootNode(&root),
+		allKeys:    keysForRootNode(&root),
+		etag:       etag,
+		fetchTime:  fetchTime,
 	}, nil
 }
 


### PR DESCRIPTION
`go vet` was complaining (with good reason) about the copy of the
configuration that `withFetchTime` does. Avoid the error by
using a `*sync.Map` instead of `sync.Map` directly.
Another possible solution would be to avoid putting the
fetch time inside the configuration, but it seems like that
would make the rest of the code more complex for not much gain.

### Related issues

Provide links to issues relating to this pull request

### Describe the solution you've provided

Provide a clear and concise description of the changes.

### Requirement checklist

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
