### PR TITLE
v7: always refresh when asked

### DIFF
--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -159,7 +159,10 @@ func NewCustomClient(cfg Config) *Client {
 // canceled while the refresh is in progress, Refresh will return but
 // the underlying HTTP request will not be canceled.
 func (client *Client) Refresh(ctx context.Context) error {
-	return client.fetcher.refreshIfOlder(ctx, time.Now(), true)
+	// Note: add a tiny bit to the current time so that we refresh
+	// even if the current time hasn't changed since the last
+	// time we refreshed.
+	return client.fetcher.refreshIfOlder(ctx, time.Now().Add(1), true)
 }
 
 // RefreshIfOlder is like Refresh but refreshes the configuration only


### PR DESCRIPTION
When the clock resolution is coarse, the most recently retrieved
configuration might still be at the current time, so ensure that can't happen.

### Related issues

Provide links to issues relating to this pull request

### Describe the solution you've provided

Provide a clear and concise description of the changes.

### Requirement checklist

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
