### PR TITLE
v7: optimize evaluation when all rules have the same value

### DIFF
--- a/v7/benchmark_test.go
+++ b/v7/benchmark_test.go
@@ -45,6 +45,38 @@ func BenchmarkGet(b *testing.B) {
 		},
 		want: "no-match",
 	}, {
+		benchName: "one-of-all-rules-same-value",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"rule": {
+					VariationID: "607147d5",
+					Value:       "match",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Email",
+						ComparisonValue:     "a@configcat.com, b@configcat.com",
+						Comparator:          opOneOf,
+						VariationID:         "385d9803",
+						Value:               "match",
+					}, {
+						ComparisonAttribute: "Country",
+						ComparisonValue:     "United",
+						Comparator:          opNotOneOf,
+						VariationID:         "385d9803",
+						Value:               "match",
+					}},
+				},
+			},
+		},
+		rule: "rule",
+		makeUser: func() User {
+			return &UserData{
+				Identifier: "unknown-identifier",
+				Email:      "x@configcat.com",
+				Country:    "United",
+			}
+		},
+		want: "match",
+	}, {
 		benchName: "less-than-with-int",
 		node: &rootNode{
 			Entries: map[string]*entry{
@@ -109,6 +141,47 @@ func BenchmarkGet(b *testing.B) {
 			}
 		},
 		want: "high-percent",
+	}, {
+		benchName: "with-percentage-all-same-value",
+		node: &rootNode{
+			Entries: map[string]*entry{
+				"bool30TrueAdvancedRules": {
+					VariationID: "607147d5",
+					Value:       "all-percent",
+					RolloutRules: []*rolloutRule{{
+						ComparisonAttribute: "Email",
+						ComparisonValue:     "a@configcat.com, b@configcat.com",
+						Comparator:          opOneOf,
+						VariationID:         "385d9803",
+						Value:               "email-match",
+					}, {
+						ComparisonAttribute: "Country",
+						ComparisonValue:     "United",
+						Comparator:          opNotOneOf,
+						VariationID:         "385d9803",
+						Value:               "country-match",
+					}},
+					PercentageRules: []percentageRule{{
+						VariationID: "607147d5",
+						Value:       "all-percent",
+						Percentage:  30,
+					}, {
+						VariationID: "385d9803",
+						Value:       "all-percent",
+						Percentage:  70,
+					}},
+				},
+			},
+		},
+		rule: "bool30TrueAdvancedRules",
+		makeUser: func() User {
+			return &UserData{
+				Identifier: "unknown-identifier",
+				Email:      "x@configcat.com",
+				Country:    "United",
+			}
+		},
+		want: "all-percent",
 	}}
 	for _, bench := range benchmarks {
 		b.Run(bench.benchName, func(b *testing.B) {


### PR DESCRIPTION

### Describe the purpose of your pull request

I've noticed in our feature flag configuration, we very often have a
set of rules that all have the same value, usually because we want to
be able to easily change the value of a flag for some particular target.

This PR optimizes that case by avoiding evaluating rules that don't need
to be evaluated.

Here are some benchmark results:

```
BenchmarkGet/one-of/get-and-make-8         	 4849270	       216.9 ns/op	     128 B/op	       2 allocs/op
BenchmarkGet/one-of/get-only-8             	26428612	        45.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkGet/one-of-all-rules-same-value/get-and-make-8         	 7332170	       164.1 ns/op	     128 B/op	       2 allocs/op
BenchmarkGet/one-of-all-rules-same-value/get-only-8             	99427462	        11.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkGet/with-percentage/get-and-make-8                     	 2821610	       429.2 ns/op	     200 B/op	       4 allocs/op
BenchmarkGet/with-percentage/get-only-8                         	 4763053	       251.7 ns/op	      72 B/op	       2 allocs/op
BenchmarkGet/with-percentage-all-same-value/get-and-make-8      	 5581408	       214.1 ns/op	     128 B/op	       2 allocs/op
BenchmarkGet/with-percentage-all-same-value/get-only-8          	26348910	        45.25 ns/op	       0 B/op	       0 allocs/op
```

The "X-all-same-value" benchmarks are the same as the X benchmarks except that all
rules evaluate to the same value. We can see, for example that for `one-of/get-only`, the performance improves
by a factor of almost 4.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
