### PR TITLE
v7: more efficient NewSnapshot

### DIFF
--- a/v7/benchmark_test.go
+++ b/v7/benchmark_test.go
@@ -2,7 +2,10 @@ package configcat
 
 import (
 	"context"
+	"fmt"
 	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
 func BenchmarkGet(b *testing.B) {
@@ -146,5 +149,19 @@ func BenchmarkGet(b *testing.B) {
 				}
 			})
 		})
+	}
+}
+
+func BenchmarkNewSnapshot(b *testing.B) {
+	c := qt.New(b)
+	b.ReportAllocs()
+	const nkeys = 100
+	m := make(map[string]interface{})
+	for i := 0; i < nkeys; i++ {
+		m[fmt.Sprint("key", i)] = false
+	}
+	logger := newTestLogger(c, LogLevelError)
+	for i := 0; i < b.N; i++ {
+		NewSnapshot(logger, m)
 	}
 }

--- a/v7/config_parser.go
+++ b/v7/config_parser.go
@@ -68,6 +68,9 @@ func (conf *config) body() string {
 }
 
 func (conf *config) getKeyAndValueForVariation(variationID string) (string, interface{}) {
+	if conf == nil {
+		return "", nil
+	}
 	kv := conf.keyValues[variationID]
 	return kv.key, kv.value
 }

--- a/v7/config_parser.go
+++ b/v7/config_parser.go
@@ -25,16 +25,19 @@ func parseConfig(jsonBody []byte, etag string, fetchTime time.Time) (*config, er
 		return nil, err
 	}
 	fixupRootNodeValues(&root)
+	return newConfig(&root, jsonBody, etag, fetchTime), nil
+}
 
+func newConfig(root *rootNode, jsonBody []byte, etag string, fetchTime time.Time) *config {
 	return &config{
 		jsonBody:   jsonBody,
-		root:       &root,
+		root:       root,
 		evaluators: new(sync.Map),
-		keyValues:  keyValuesForRootNode(&root),
-		allKeys:    keysForRootNode(&root),
+		keyValues:  keyValuesForRootNode(root),
+		allKeys:    keysForRootNode(root),
 		etag:       etag,
 		fetchTime:  fetchTime,
-	}, nil
+	}
 }
 
 func (conf *config) equal(c1 *config) bool {

--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -140,13 +140,7 @@ func NewCustomClient(cfg Config) *Client {
 	if cfg.PollInterval < 1 {
 		cfg.PollInterval = DefaultPollInterval
 	}
-	if cfg.Logger == nil {
-		cfg.Logger = DefaultLogger(LogLevelWarn)
-	}
-	logger := &leveledLogger{
-		level:  cfg.Logger.GetLevel(),
-		Logger: cfg.Logger,
-	}
+	logger := newLeveledLogger(cfg.Logger)
 	return &Client{
 		cfg:          cfg,
 		logger:       logger,

--- a/v7/configserver_test.go
+++ b/v7/configserver_test.go
@@ -147,13 +147,6 @@ func marshalJSON(x interface{}) string {
 	return string(data)
 }
 
-func testLeveledLogger(t testing.TB) *leveledLogger {
-	return &leveledLogger{
-		level:  LogLevelDebug,
-		Logger: newTestLogger(t, LogLevelDebug),
-	}
-}
-
 // testLogger implements the Logger interface by logging to the test.T
 // instance.
 type testLogger struct {

--- a/v7/eval.go
+++ b/v7/eval.go
@@ -112,7 +112,7 @@ func entryEvaluator(key string, node *entry, tinfo *userTypeInfo) entryEvalFunc 
 				"Read more: https://configcat.com/docs/advanced/user-object.", key)
 		}
 		if logger.enabled(LogLevelInfo) {
-			logger.Infof("Returning %v.", node.Value)
+			logger.Infof("Returning %v=%v.", key, node.Value)
 		}
 		return node.Value, node.VariationID
 	}

--- a/v7/logger.go
+++ b/v7/logger.go
@@ -35,6 +35,16 @@ func DefaultLogger(level LogLevel) Logger {
 	return logger
 }
 
+func newLeveledLogger(logger Logger) *leveledLogger {
+	if logger == nil {
+		logger = DefaultLogger(LogLevelWarn)
+	}
+	return &leveledLogger{
+		level:  logger.GetLevel(),
+		Logger: logger,
+	}
+}
+
 // leveledLogger wraps a Logger for efficiency reasons: it's a static type
 // rather than an interface so the compiler can inline the level check
 // and thus avoid the allocation for the arguments.

--- a/v7/snapshot.go
+++ b/v7/snapshot.go
@@ -4,42 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 )
-
-// NewSnapshot returns a snapshot that always returns the given values.
-//
-// Each entry in the values map is keyed by a flag
-// name and holds the value that the snapshot will return
-// for that flag. Each value must be one of the types
-// bool, int, float64, or string.
-func NewSnapshot(logger Logger, values map[string]interface{}) (*Snapshot, error) {
-	entries := make(map[string]*entry, len(values))
-	for name, val := range values {
-		var et entryType
-		switch val.(type) {
-		case bool:
-			et = boolEntry
-		case int:
-			et = intEntry
-		case float64:
-			et = floatEntry
-		case string:
-			et = stringEntry
-		default:
-			return nil, fmt.Errorf("value for flag %q has unexpected type %T (%v); must be bool, int, float64 or string", name, val, val)
-		}
-		entries[name] = &entry{
-			Value: val,
-			Type:  et,
-		}
-	}
-	cfg := newConfig(&rootNode{
-		Entries: entries,
-		// Note: Preferences aren't used by the snapshot code.
-	}, nil, "", time.Now())
-	return newSnapshot(cfg, nil, newLeveledLogger(logger)), nil
-}
 
 // Snapshot holds a snapshot of the Configcat configuration.
 // A snapshot is immutable once taken.
@@ -47,11 +12,61 @@ func NewSnapshot(logger Logger, values map[string]interface{}) (*Snapshot, error
 // A nil snapshot is OK to use and acts like a configuration
 // with no keys.
 type Snapshot struct {
-	logger *leveledLogger
-	config *config
-	user   reflect.Value
+	logger  *leveledLogger
+	config  *config
+	user    reflect.Value
+	allKeys []string
 	// evaluators maps keyID to the evaluator for that key.
 	evaluators []entryEvalFunc
+}
+
+// NewSnapshot returns a snapshot that always returns the given values.
+//
+// Each entry in the values map is keyed by a flag
+// name and holds the value that the snapshot will return
+// for that flag. Each value must be one of the types
+// bool, int, float64, or string.
+//
+// The returned snapshot does not support variation IDs. That is, given a
+// snapshot s returned by NewSnapshot:
+// - s.GetKeyValueForVariationID returns "", nil.
+// - s.GetVariationID returns "".
+// - s.GetVariationIDs returns nil.
+func NewSnapshot(logger Logger, values map[string]interface{}) (*Snapshot, error) {
+	valueSlice := make([]interface{}, numKeys())
+	keys := make([]string, 0, len(values))
+
+	for name, val := range values {
+		switch val.(type) {
+		case bool, int, float64, string:
+		default:
+			return nil, fmt.Errorf("value for flag %q has unexpected type %T (%#v); must be bool, int, float64 or string", name, val, val)
+		}
+		id := idForKey(name, true)
+		if int(id) >= len(valueSlice) {
+			// We've added a new key, so expand the slices.
+			// This should be a rare case, so don't worry about
+			// this happening several times within this loop.
+			valueSlice1 := make([]interface{}, id+1)
+			copy(valueSlice1, valueSlice)
+			valueSlice = valueSlice1
+		}
+		valueSlice[id] = val
+		keys = append(keys, name)
+	}
+	// Save some allocations by using the same closure for every key.
+	eval := func(id keyID, logger *leveledLogger, userv reflect.Value) (interface{}, string) {
+		return valueSlice[id], ""
+	}
+	evaluators := make([]entryEvalFunc, len(valueSlice))
+	for i := range evaluators {
+		evaluators[i] = eval
+	}
+	return &Snapshot{
+		logger:     newLeveledLogger(logger),
+		evaluators: evaluators,
+		allKeys:    keys,
+	}, nil
 }
 
 func newSnapshot(cfg *config, user User, logger *leveledLogger) *Snapshot {
@@ -67,6 +82,7 @@ func newSnapshot(cfg *config, user User, logger *leveledLogger) *Snapshot {
 	if cfg == nil {
 		return snap
 	}
+	snap.allKeys = cfg.allKeys
 	evaluators, err := cfg.evaluatorsForUserType(userType)
 	if err != nil {
 		logger.Errorf("%v", err)
@@ -79,8 +95,11 @@ func newSnapshot(cfg *config, user User, logger *leveledLogger) *Snapshot {
 // WithUser returns a copy of s associated with the
 // given user. If snap is nil, it returns nil.
 func (snap *Snapshot) WithUser(user User) *Snapshot {
-	if snap == nil {
-		return nil
+	if snap == nil || snap.config == nil {
+		// Note: when there's no config, we know there are no
+		// rules that can change the values returned, so no
+		// need to do anything.
+		return snap
 	}
 	return newSnapshot(snap.config, user, snap.logger)
 }
@@ -110,7 +129,11 @@ func (snap *Snapshot) valueAndVariationID(id keyID, key string) (interface{}, st
 			" Here are the available keys: %s", key, strings.Join(snap.GetAllKeys(), ","))
 		return nil, ""
 	}
-	return eval(snap.logger, snap.user)
+	val, variationID := eval(id, snap.logger, snap.user)
+	if snap.logger.enabled(LogLevelInfo) {
+		snap.logger.Infof("Returning %v=%v.", key, val)
+	}
+	return val, variationID
 }
 
 // GetValue returns a feature flag value regardless of type. If there is no
@@ -123,7 +146,7 @@ func (snap *Snapshot) valueAndVariationID(id keyID, key string) (interface{}, st
 //	someFlag := configcat.Bool("someFlag", false)
 // 	value := someFlag.Get(snap)
 func (snap *Snapshot) GetValue(key string) interface{} {
-	return snap.value(idForKey(key, true), key)
+	return snap.value(idForKey(key, false), key)
 }
 
 // GetKeyValueForVariationID returns the key and value that
@@ -144,22 +167,23 @@ func (snap *Snapshot) GetKeyValueForVariationID(id string) (string, interface{})
 // GetVariationIDs returns all variation IDs in the current configuration
 // that apply to the current user.
 func (snap *Snapshot) GetVariationIDs() []string {
-	if snap == nil {
+	if snap == nil || snap.config == nil {
 		return nil
 	}
 	keys := snap.config.keys()
 	ids := make([]string, 0, len(keys))
 	for _, key := range keys {
-		_, varID := snap.evaluators[idForKey(key, false)](snap.logger, snap.user)
+		id := idForKey(key, false)
+		_, varID := snap.evaluators[id](id, snap.logger, snap.user)
 		ids = append(ids, varID)
 	}
 	return ids
 }
 
-// GetAllKeys returns all the known keys.
+// GetAllKeys returns all the known keys in arbitrary order.
 func (snap *Snapshot) GetAllKeys() []string {
 	if snap == nil {
 		return nil
 	}
-	return snap.config.keys()
+	return snap.allKeys
 }

--- a/v7/snapshot_test.go
+++ b/v7/snapshot_test.go
@@ -236,6 +236,10 @@ func TestLogging(t *testing.T) {
 
 func TestNewSnapshot(t *testing.T) {
 	c := qt.New(t)
+	// Make sure there's another flag in there so even when we run
+	// the test on its own, we're still testing the case where the
+	// flag ids don't start from zero.
+	Bool("something", false)
 	values := map[string]interface{}{
 		"intFlag":    1,
 		"floatFlag":  2.0,
@@ -249,6 +253,19 @@ func TestNewSnapshot(t *testing.T) {
 	}
 	// Sanity check that it works OK with Flag values.
 	c.Assert(Int("intFlag", 0).Get(snap), qt.Equals, 1)
+	c.Assert(snap.GetAllKeys(), qt.ContentEquals, []string{
+		"intFlag",
+		"floatFlag",
+		"stringFlag",
+		"boolFlag",
+	})
+	c.Assert(snap.GetVariationID("intFlag"), qt.Equals, "")
+	c.Assert(snap.GetVariationIDs(), qt.IsNil)
+	id, val := snap.GetKeyValueForVariationID("")
+	c.Assert(id, qt.Equals, "")
+	c.Assert(val, qt.Equals, nil)
+
+	c.Assert(snap.WithUser(&UserData{}), qt.Equals, snap)
 }
 
 func TestNewSnapshotWithUnknownType(t *testing.T) {

--- a/v7/snapshot_test.go
+++ b/v7/snapshot_test.go
@@ -233,3 +233,29 @@ func TestLogging(t *testing.T) {
 		})
 	}
 }
+
+func TestNewSnapshot(t *testing.T) {
+	c := qt.New(t)
+	values := map[string]interface{}{
+		"intFlag":    1,
+		"floatFlag":  2.0,
+		"stringFlag": "three",
+		"boolFlag":   true,
+	}
+	snap, err := NewSnapshot(newTestLogger(t, LogLevelDebug), values)
+	c.Assert(err, qt.IsNil)
+	for key, want := range values {
+		c.Assert(snap.GetValue(key), qt.Equals, want)
+	}
+	// Sanity check that it works OK with Flag values.
+	c.Assert(Int("intFlag", 0).Get(snap), qt.Equals, 1)
+}
+
+func TestNewSnapshotWithUnknownType(t *testing.T) {
+	c := qt.New(t)
+	snap, err := NewSnapshot(newTestLogger(t, LogLevelDebug), map[string]interface{}{
+		"badVal": int64(1),
+	})
+	c.Check(err, qt.ErrorMatches, `value for flag "badVal" has unexpected type int64 \(1\); must be bool, int, float64 or string`)
+	c.Check(snap, qt.IsNil)
+}

--- a/v7/snapshot_test.go
+++ b/v7/snapshot_test.go
@@ -40,7 +40,7 @@ var loggingTests = []struct {
 	expectValue: "value",
 	expectLogs: []string{
 		"INFO: fetching from $HOST_URL",
-		"INFO: Returning value.",
+		"INFO: Returning key=value.",
 	},
 }, {
 	testName: "RolloutRulesButNoUser",
@@ -63,7 +63,7 @@ var loggingTests = []struct {
 	expectLogs: []string{
 		"INFO: fetching from $HOST_URL",
 		"WARN: Evaluating GetValue(key). UserObject missing! You should pass a UserObject to GetValueForUser() in order to make targeting work properly. Read more: https://configcat.com/docs/advanced/user-object.",
-		"INFO: Returning defaultValue.",
+		"INFO: Returning key=defaultValue.",
 	},
 }, {
 	testName: "RolloutRulesWithUser",
@@ -95,6 +95,7 @@ var loggingTests = []struct {
 		"INFO: fetching from $HOST_URL",
 		"INFO: Evaluating rule: [Identifier:y] [CONTAINS] [x] => no match",
 		"INFO: Evaluating rule: [Identifier:y] [CONTAINS] [y] => match, returning: v2",
+		"INFO: Returning key=v2.",
 	},
 }, {
 	testName: "PercentageRulesButNoUser",
@@ -118,7 +119,7 @@ var loggingTests = []struct {
 	expectLogs: []string{
 		"INFO: fetching from $HOST_URL",
 		"WARN: Evaluating GetValue(key). UserObject missing! You should pass a UserObject to GetValueForUser() in order to make targeting work properly. Read more: https://configcat.com/docs/advanced/user-object.",
-		"INFO: Returning defaultValue.",
+		"INFO: Returning key=defaultValue.",
 	},
 }, {
 	testName: "PercentageRulesWithUser",
@@ -144,7 +145,7 @@ var loggingTests = []struct {
 	expectValue: "high-percent",
 	expectLogs: []string{
 		"INFO: fetching from $HOST_URL",
-		"INFO: Evaluating % options. Returning high-percent",
+		"INFO: Returning key=high-percent.",
 	},
 }, {
 	testName: "MatchErrorInUser",
@@ -170,7 +171,7 @@ var loggingTests = []struct {
 	expectLogs: []string{
 		"INFO: fetching from $HOST_URL",
 		"INFO: Evaluating rule: [Identifier:bogus] [< (SemVer)] [1.2.3] => SKIP rule. Validation error: No Major.Minor.Patch elements found",
-		"INFO: Returning defaultValue.",
+		"INFO: Returning key=defaultValue.",
 	},
 }, {
 	testName: "MatchErrorRules",
@@ -196,7 +197,7 @@ var loggingTests = []struct {
 	expectLogs: []string{
 		"INFO: fetching from $HOST_URL",
 		"INFO: Evaluating rule: [Identifier:1.2.3] [< (SemVer)] [bogus] => SKIP rule. Validation error: No Major.Minor.Patch elements found",
-		"INFO: Returning defaultValue.",
+		"INFO: Returning key=defaultValue.",
 	},
 }}
 


### PR DESCRIPTION
### Describe the purpose of your pull request

Rather than creating a fake configuration just for the static snapshot,
we can just create the evaluators directly, which means that we can
do the creation faster and in O(1) allocations.

There's a small amount of performance regression in the other benchmarks,
but nothing really significant IMHO.

```
name                                   old time/op    new time/op    delta
Get/one-of/get-and-make-8                 272ns ± 0%     295ns ± 9%   +8.50%  (p=0.008 n=5+5)
Get/one-of/get-only-8                    53.4ns ± 0%    59.2ns ± 4%  +10.92%  (p=0.008 n=5+5)
Get/less-than-with-int/get-and-make-8     194ns ± 4%     209ns ± 1%   +7.24%  (p=0.008 n=5+5)
Get/less-than-with-int/get-only-8        22.6ns ± 0%    23.0ns ± 0%   +1.60%  (p=0.008 n=5+5)
Get/with-percentage/get-and-make-8        536ns ± 1%     555ns ± 1%   +3.46%  (p=0.008 n=5+5)
Get/with-percentage/get-only-8            322ns ± 0%     322ns ± 0%     ~     (p=0.643 n=5+5)
NewSnapshot-8                            41.3µs ± 2%     8.9µs ± 2%  -78.43%  (p=0.008 n=5+5)

name                                   old alloc/op   new alloc/op   delta
Get/one-of/get-and-make-8                  128B ± 0%      160B ± 0%  +25.00%  (p=0.008 n=5+5)
Get/one-of/get-only-8                     0.00B          0.00B          ~     (all equal)
Get/less-than-with-int/get-and-make-8     72.0B ± 0%    104.0B ± 0%  +44.44%  (p=0.008 n=5+5)
Get/less-than-with-int/get-only-8         0.00B          0.00B          ~     (all equal)
Get/with-percentage/get-and-make-8         200B ± 0%      232B ± 0%  +16.00%  (p=0.008 n=5+5)
Get/with-percentage/get-only-8            72.0B ± 0%     72.0B ± 0%     ~     (all equal)
NewSnapshot-8                            24.0kB ± 0%     4.6kB ± 0%  -80.67%  (p=0.008 n=5+5)

name                                   old allocs/op  new allocs/op  delta
Get/one-of/get-and-make-8                  2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Get/one-of/get-only-8                      0.00           0.00          ~     (all equal)
Get/less-than-with-int/get-and-make-8      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Get/less-than-with-int/get-only-8          0.00           0.00          ~     (all equal)
Get/with-percentage/get-and-make-8         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
Get/with-percentage/get-only-8             2.00 ± 0%      2.00 ± 0%     ~     (all equal)
NewSnapshot-8                               218 ± 0%         6 ± 0%  -97.25%  (p=0.008 n=5+5)
```

Also clarify the contract of `NewSnapshot` with repect to variation IDs and fix
it so that it doesn't return a slice of empty variation IDs.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
