### PR TITLE
v7: add tests for log output

### DIFF
--- a/v7/configserver_test.go
+++ b/v7/configserver_test.go
@@ -157,14 +157,14 @@ func testLeveledLogger(t testing.TB) *leveledLogger {
 // testLogger implements the Logger interface by logging to the test.T
 // instance.
 type testLogger struct {
-	t     testing.TB
-	level LogLevel
+	logFunc func(string, ...interface{})
+	level   LogLevel
 }
 
 func newTestLogger(t testing.TB, level LogLevel) Logger {
 	return &testLogger{
-		t:     t,
-		level: level,
+		logFunc: t.Logf,
+		level:   level,
 	}
 }
 
@@ -221,13 +221,13 @@ func (log testLogger) Errorln(args ...interface{}) {
 }
 
 func (log testLogger) logf(level string, format string, args ...interface{}) {
-	log.t.Logf("%s: %s", level, fmt.Sprintf(format, args...))
+	log.logFunc("%s: %s", level, fmt.Sprintf(format, args...))
 }
 
 func (log testLogger) log(level string, args ...interface{}) {
-	log.t.Logf("%s: %s", level, fmt.Sprint(args...))
+	log.logFunc("%s: %s", level, fmt.Sprint(args...))
 }
 
 func (log testLogger) logln(level string, args ...interface{}) {
-	log.t.Logf("%s: %s", level, fmt.Sprintln(args...))
+	log.logFunc("%s: %s", level, fmt.Sprintln(args...))
 }

--- a/v7/eval.go
+++ b/v7/eval.go
@@ -162,7 +162,7 @@ func entryEvaluator(key string, node *entry, tinfo *userTypeInfo) entryEvalFunc 
 						err,
 					)
 				}
-			} else if logger.enabled(LogLevelDebug) {
+			} else if logger.enabled(LogLevelInfo) {
 				logger.Infof("Evaluating rule: [%s:%s] [%s] [%s] => no match",
 					rule.ComparisonAttribute,
 					attrInfos[i].asString(userv),

--- a/v7/eval_test.go
+++ b/v7/eval_test.go
@@ -334,7 +334,7 @@ type opTest struct {
 
 func (test *opTest) run(c *qt.C, ectx *evalTestContext, user User) {
 	c.Run(test.testName, func(c *qt.C) {
-		ectx.logger.t = c
+		ectx.logger.logFunc = c.Logf
 		c.Logf("operator %v; cmpVal %v; want %v", test.op, test.cmpVal, test.want)
 		ectx.srv.setResponseJSON(&rootNode{
 			Entries: map[string]*entry{

--- a/v7/rollout_integration_test.go
+++ b/v7/rollout_integration_test.go
@@ -117,7 +117,7 @@ func (test integrationTest) runTest(t *testing.T) {
 			for i, settingKey := range settingKeys {
 				t.Run(fmt.Sprintf("key-%s", settingKey), func(t *testing.T) {
 					t.Logf("rule:\n%s", describeRules(client.fetcher.current(), settingKey))
-					tlogger.t = t
+					tlogger.logFunc = t.Logf
 					var val interface{}
 					switch test.kind {
 					case valueKind:

--- a/v7/snapshot_test.go
+++ b/v7/snapshot_test.go
@@ -1,6 +1,9 @@
 package configcat
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -21,4 +24,212 @@ func TestNilSnapshot(t *testing.T) {
 	// Test one flag type as proxy for the others, as they all use
 	// the same underlying mechanism.
 	c.Assert(Bool("hello", true).Get(nil), qt.Equals, true)
+}
+
+var loggingTests = []struct {
+	testName    string
+	config      *rootNode
+	key         string
+	user        User
+	expectValue interface{}
+	expectLogs  []string
+}{{
+	testName:    "NoRules",
+	config:      rootNodeWithKeyValue("key", "value", stringEntry),
+	key:         "key",
+	expectValue: "value",
+	expectLogs: []string{
+		"INFO: fetching from $HOST_URL",
+		"INFO: Returning value.",
+	},
+}, {
+	testName: "RolloutRulesButNoUser",
+	config: &rootNode{
+		Entries: map[string]*entry{
+			"key": {
+				Value: "defaultValue",
+				Type:  stringEntry,
+				RolloutRules: []*rolloutRule{{
+					Value:               "e",
+					ComparisonAttribute: "attr",
+					ComparisonValue:     "x",
+					Comparator:          opContains,
+				}},
+			},
+		},
+	},
+	key:         "key",
+	expectValue: "defaultValue",
+	expectLogs: []string{
+		"INFO: fetching from $HOST_URL",
+		"WARN: Evaluating GetValue(key). UserObject missing! You should pass a UserObject to GetValueForUser() in order to make targeting work properly. Read more: https://configcat.com/docs/advanced/user-object.",
+		"INFO: Returning defaultValue.",
+	},
+}, {
+	testName: "RolloutRulesWithUser",
+	config: &rootNode{
+		Entries: map[string]*entry{
+			"key": {
+				Value: "defaultValue",
+				Type:  stringEntry,
+				RolloutRules: []*rolloutRule{{
+					Value:               "v1",
+					ComparisonAttribute: "Identifier",
+					Comparator:          opContains,
+					ComparisonValue:     "x",
+				}, {
+					Value:               "v2",
+					ComparisonAttribute: "Identifier",
+					Comparator:          opContains,
+					ComparisonValue:     "y",
+				}},
+			},
+		},
+	},
+	key: "key",
+	user: &UserData{
+		Identifier: "y",
+	},
+	expectValue: "v2",
+	expectLogs: []string{
+		"INFO: fetching from $HOST_URL",
+		"INFO: Evaluating rule: [Identifier:y] [CONTAINS] [x] => no match",
+		"INFO: Evaluating rule: [Identifier:y] [CONTAINS] [y] => match, returning: v2",
+	},
+}, {
+	testName: "PercentageRulesButNoUser",
+	config: &rootNode{
+		Entries: map[string]*entry{
+			"key": {
+				Value: "defaultValue",
+				Type:  stringEntry,
+				PercentageRules: []percentageRule{{
+					Value:      "low-percent",
+					Percentage: 30,
+				}, {
+					Value:      "high-percent",
+					Percentage: 70,
+				}},
+			},
+		},
+	},
+	key:         "key",
+	expectValue: "defaultValue",
+	expectLogs: []string{
+		"INFO: fetching from $HOST_URL",
+		"WARN: Evaluating GetValue(key). UserObject missing! You should pass a UserObject to GetValueForUser() in order to make targeting work properly. Read more: https://configcat.com/docs/advanced/user-object.",
+		"INFO: Returning defaultValue.",
+	},
+}, {
+	testName: "PercentageRulesWithUser",
+	config: &rootNode{
+		Entries: map[string]*entry{
+			"key": {
+				Value: "defaultValue",
+				Type:  stringEntry,
+				PercentageRules: []percentageRule{{
+					Value:      "low-percent",
+					Percentage: 1,
+				}, {
+					Value:      "high-percent",
+					Percentage: 99,
+				}},
+			},
+		},
+	},
+	key: "key",
+	user: &UserData{
+		Identifier: "y",
+	},
+	expectValue: "high-percent",
+	expectLogs: []string{
+		"INFO: fetching from $HOST_URL",
+		"INFO: Evaluating % options. Returning high-percent",
+	},
+}, {
+	testName: "MatchErrorInUser",
+	config: &rootNode{
+		Entries: map[string]*entry{
+			"key": {
+				Value: "defaultValue",
+				Type:  stringEntry,
+				RolloutRules: []*rolloutRule{{
+					Value:               "e",
+					ComparisonAttribute: "Identifier",
+					ComparisonValue:     "1.2.3",
+					Comparator:          opLessSemver,
+				}},
+			},
+		},
+	},
+	key:         "key",
+	expectValue: "defaultValue",
+	user: &UserData{
+		Identifier: "bogus",
+	},
+	expectLogs: []string{
+		"INFO: fetching from $HOST_URL",
+		"INFO: Evaluating rule: [Identifier:bogus] [< (SemVer)] [1.2.3] => SKIP rule. Validation error: No Major.Minor.Patch elements found",
+		"INFO: Returning defaultValue.",
+	},
+}, {
+	testName: "MatchErrorRules",
+	config: &rootNode{
+		Entries: map[string]*entry{
+			"key": {
+				Value: "defaultValue",
+				Type:  stringEntry,
+				RolloutRules: []*rolloutRule{{
+					Value:               "e",
+					ComparisonAttribute: "Identifier",
+					ComparisonValue:     "bogus",
+					Comparator:          opLessSemver,
+				}},
+			},
+		},
+	},
+	key:         "key",
+	expectValue: "defaultValue",
+	user: &UserData{
+		Identifier: "1.2.3",
+	},
+	expectLogs: []string{
+		"INFO: fetching from $HOST_URL",
+		"INFO: Evaluating rule: [Identifier:1.2.3] [< (SemVer)] [bogus] => SKIP rule. Validation error: No Major.Minor.Patch elements found",
+		"INFO: Returning defaultValue.",
+	},
+}}
+
+func TestLogging(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range loggingTests {
+		c.Run(test.testName, func(c *qt.C) {
+			var logs []string
+			srv := newConfigServer(t)
+			cfg := srv.config()
+			cfg.PollingMode = Manual
+			cfg.Logger = &testLogger{
+				logFunc: func(f string, a ...interface{}) {
+					s := fmt.Sprintf(f, a...)
+					if !strings.HasPrefix(s, "DEBUG: ") {
+						logs = append(logs, s)
+					}
+				},
+				level: LogLevelInfo,
+			}
+			client := NewCustomClient(cfg)
+			defer client.Close()
+			srv.setResponseJSON(test.config)
+			client.Refresh(context.Background())
+
+			expectLogs := append([]string(nil), test.expectLogs...)
+			for i := range expectLogs {
+				expectLogs[i] = strings.ReplaceAll(expectLogs[i], "$HOST_URL", cfg.BaseURL)
+			}
+
+			value := client.GetStringValue(test.key, "", test.user)
+			c.Check(value, qt.Equals, test.expectValue)
+			c.Check(logs, qt.DeepEquals, expectLogs)
+		})
+	}
 }


### PR DESCRIPTION
After the PR feedback on https://github.com/configcat/go-sdk/pull/41,
I realised that a significant current issue is the lack of tests for
the expected logging output, meaning that it's easy to change
code such that the logged output changes without breaking tests.

This PR adds some tests for logs.

We can see that some improvement could be made - for example
none of the logs mention what key is currently being evaluated - but
we'll leave that for another PR.

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
