### PR TITLE
v7: factor out internal/wireconfig package

### DIFF
--- a/v7/benchmark_test.go
+++ b/v7/benchmark_test.go
@@ -5,33 +5,34 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 	qt "github.com/frankban/quicktest"
 )
 
 func BenchmarkGet(b *testing.B) {
 	benchmarks := []struct {
 		benchName string
-		node      *rootNode
+		node      *wireconfig.RootNode
 		rule      string
 		makeUser  func() User
 		want      string
 	}{{
 		benchName: "one-of",
-		node: &rootNode{
-			Entries: map[string]*entry{
+		node: &wireconfig.RootNode{
+			Entries: map[string]*wireconfig.Entry{
 				"rule": {
 					VariationID: "607147d5",
 					Value:       "no-match",
-					RolloutRules: []*rolloutRule{{
+					RolloutRules: []*wireconfig.RolloutRule{{
 						ComparisonAttribute: "Email",
 						ComparisonValue:     "a@configcat.com, b@configcat.com",
-						Comparator:          opOneOf,
+						Comparator:          wireconfig.OpOneOf,
 						VariationID:         "385d9803",
 						Value:               "email-match",
 					}, {
 						ComparisonAttribute: "Country",
 						ComparisonValue:     "United",
-						Comparator:          opNotOneOf,
+						Comparator:          wireconfig.OpNotOneOf,
 						VariationID:         "385d9803",
 						Value:               "country-match",
 					}},
@@ -49,15 +50,15 @@ func BenchmarkGet(b *testing.B) {
 		want: "no-match",
 	}, {
 		benchName: "less-than-with-int",
-		node: &rootNode{
-			Entries: map[string]*entry{
+		node: &wireconfig.RootNode{
+			Entries: map[string]*wireconfig.Entry{
 				"rule": {
 					VariationID: "607147d5",
 					Value:       "no-match",
-					RolloutRules: []*rolloutRule{{
+					RolloutRules: []*wireconfig.RolloutRule{{
 						ComparisonAttribute: "Age",
 						ComparisonValue:     "21",
-						Comparator:          opLessNum,
+						Comparator:          wireconfig.OpLessNum,
 						VariationID:         "385d9803",
 						Value:               "age-match",
 					}},
@@ -73,25 +74,25 @@ func BenchmarkGet(b *testing.B) {
 		want: "age-match",
 	}, {
 		benchName: "with-percentage",
-		node: &rootNode{
-			Entries: map[string]*entry{
+		node: &wireconfig.RootNode{
+			Entries: map[string]*wireconfig.Entry{
 				"bool30TrueAdvancedRules": {
 					VariationID: "607147d5",
 					Value:       "no-match",
-					RolloutRules: []*rolloutRule{{
+					RolloutRules: []*wireconfig.RolloutRule{{
 						ComparisonAttribute: "Email",
 						ComparisonValue:     "a@configcat.com, b@configcat.com",
-						Comparator:          opOneOf,
+						Comparator:          wireconfig.OpOneOf,
 						VariationID:         "385d9803",
 						Value:               "email-match",
 					}, {
 						ComparisonAttribute: "Country",
 						ComparisonValue:     "United",
-						Comparator:          opNotOneOf,
+						Comparator:          wireconfig.OpNotOneOf,
 						VariationID:         "385d9803",
 						Value:               "country-match",
 					}},
-					PercentageRules: []percentageRule{{
+					PercentageRules: []wireconfig.PercentageRule{{
 						VariationID: "607147d5",
 						Value:       "low-percent",
 						Percentage:  30,

--- a/v7/config_fetcher.go
+++ b/v7/config_fetcher.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 )
 
 const configJSONName = "config_v5"
@@ -239,13 +241,13 @@ func (f *configFetcher) fetchHTTP(ctx context.Context, baseURL string, prevConfi
 			return config, baseURL, nil
 		}
 		redirect := *preferences.Redirect
-		if redirect == forceRedirect {
+		if redirect == wireconfig.ForceRedirect {
 			f.logger.Infof("forced redirect to %v (count %d)", preferences.URL, i+1)
 			baseURL = preferences.URL
 			continue
 		}
 		if f.urlIsCustom {
-			if redirect == noRedirect {
+			if redirect == wireconfig.Nodirect {
 				// The config is available, but we won't respect the redirection
 				// request for a custom URL.
 				f.logger.Infof("config fetched but refusing to redirect from custom URL without forced redirection")
@@ -266,13 +268,13 @@ func (f *configFetcher) fetchHTTP(ctx context.Context, baseURL string, prevConfi
 				"Dashboard: https://app.configcat.com/organization/data-governance. " +
 				"Only Organization Admins can access this preference.",
 		)
-		if redirect == noRedirect {
+		if redirect == wireconfig.Nodirect {
 			// We've already got the configuration data, we'll just fetch
 			// from the redirected URL next time.
 			f.logger.Infof("redirection on next fetch to %v", baseURL)
 			return config, baseURL, nil
 		}
-		if redirect != shouldRedirect {
+		if redirect != wireconfig.ShouldRedirect {
 			return nil, "", fmt.Errorf("unknown redirection kind %d in response", redirect)
 		}
 		f.logger.Infof("redirecting to %v", baseURL)

--- a/v7/eval_test.go
+++ b/v7/eval_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 	qt "github.com/frankban/quicktest"
 )
 
@@ -80,12 +81,12 @@ func TestOpCmpNumWithNumericValue(t *testing.T) {
 	c := qt.New(t)
 	ectx := newEvalTestContext(c)
 
-	for _, op := range []operator{
-		opEqNum,
-		opLessNum,
-		opLessEqNum,
-		opGreaterNum,
-		opGreaterEqNum,
+	for _, op := range []wireconfig.Operator{
+		wireconfig.OpEqNum,
+		wireconfig.OpLessNum,
+		wireconfig.OpLessEqNum,
+		wireconfig.OpGreaterNum,
+		wireconfig.OpGreaterEqNum,
 	} {
 		for _, tv := range []interface{}{int8(0), int16(0), int32(0), int64(0), uint8(0), uint16(0), uint32(0), uint64(0), float32(0), float64(0)} {
 			t := reflect.TypeOf(tv)
@@ -120,12 +121,12 @@ func TestOpCmpNumWithInvalidCmpVal(t *testing.T) {
 	c := qt.New(t)
 	ectx := newEvalTestContext(c)
 
-	for _, op := range []operator{
-		opEqNum,
-		opLessNum,
-		opLessEqNum,
-		opGreaterNum,
-		opGreaterEqNum,
+	for _, op := range []wireconfig.Operator{
+		wireconfig.OpEqNum,
+		wireconfig.OpLessNum,
+		wireconfig.OpLessEqNum,
+		wireconfig.OpGreaterNum,
+		wireconfig.OpGreaterEqNum,
 	} {
 		for _, tv := range []interface{}{int8(0), int16(0), int32(0), int64(0), uint8(0), uint16(0), uint32(0), uint64(0), float32(0), float64(0)} {
 			(&opTest{
@@ -144,34 +145,34 @@ func TestOpCmpNumWithStringValue(t *testing.T) {
 
 	tests := []struct {
 		s      string
-		op     operator
+		op     wireconfig.Operator
 		cmpVal string
 		want   bool
 	}{
-		{"1.5", opEqNum, "1.5", true},
-		{"1.5", opEqNum, "1.6", false},
-		{"", opEqNum, "0", false},
-		{"1.5", opNotEqNum, "1.5", false},
-		{"1.5", opLessNum, "1.6", true},
-		{"1.6", opLessNum, "1.5", false},
-		{"1.5", opLessNum, "1.5", false},
-		{"1.5", opLessEqNum, "1.5", true},
-		{"1.5", opLessEqNum, "1.6", true},
-		{"1.6", opLessEqNum, "1.5", false},
+		{"1.5", wireconfig.OpEqNum, "1.5", true},
+		{"1.5", wireconfig.OpEqNum, "1.6", false},
+		{"", wireconfig.OpEqNum, "0", false},
+		{"1.5", wireconfig.OpNotEqNum, "1.5", false},
+		{"1.5", wireconfig.OpLessNum, "1.6", true},
+		{"1.6", wireconfig.OpLessNum, "1.5", false},
+		{"1.5", wireconfig.OpLessNum, "1.5", false},
+		{"1.5", wireconfig.OpLessEqNum, "1.5", true},
+		{"1.5", wireconfig.OpLessEqNum, "1.6", true},
+		{"1.6", wireconfig.OpLessEqNum, "1.5", false},
 		// Invalid numbers always compare false.
-		{"bad", opEqNum, "1.5", false},
-		{"bad", opNotEqNum, "1.5", false},
-		{"bad", opLessNum, "1.5", false},
-		{"bad", opLessEqNum, "1.5", false},
-		{"bad", opGreaterNum, "1.5", false},
-		{"bad", opGreaterEqNum, "1.5", false},
+		{"bad", wireconfig.OpEqNum, "1.5", false},
+		{"bad", wireconfig.OpNotEqNum, "1.5", false},
+		{"bad", wireconfig.OpLessNum, "1.5", false},
+		{"bad", wireconfig.OpLessEqNum, "1.5", false},
+		{"bad", wireconfig.OpGreaterNum, "1.5", false},
+		{"bad", wireconfig.OpGreaterEqNum, "1.5", false},
 		// NaN always compares false.
-		{"NaN", opEqNum, "1.5", false},
-		{"NaN", opNotEqNum, "1.5", false},
-		{"NaN", opLessNum, "1.5", false},
-		{"NaN", opLessEqNum, "1.5", false},
-		{"NaN", opGreaterNum, "1.5", false},
-		{"NaN", opGreaterEqNum, "1.5", false},
+		{"NaN", wireconfig.OpEqNum, "1.5", false},
+		{"NaN", wireconfig.OpNotEqNum, "1.5", false},
+		{"NaN", wireconfig.OpLessNum, "1.5", false},
+		{"NaN", wireconfig.OpLessEqNum, "1.5", false},
+		{"NaN", wireconfig.OpGreaterNum, "1.5", false},
+		{"NaN", wireconfig.OpGreaterEqNum, "1.5", false},
 	}
 	for _, test := range tests {
 		s := test.s
@@ -193,13 +194,13 @@ func TestOpSemverWithNonStringDoesNotMatch(t *testing.T) {
 	user := &struct {
 		X int
 	}{1}
-	for _, op := range []operator{
-		opOneOfSemver,
-		opNotOneOfSemver,
-		opLessSemver,
-		opLessEqSemver,
-		opGreaterSemver,
-		opGreaterEqSemver,
+	for _, op := range []wireconfig.Operator{
+		wireconfig.OpOneOfSemver,
+		wireconfig.OpNotOneOfSemver,
+		wireconfig.OpLessSemver,
+		wireconfig.OpLessEqSemver,
+		wireconfig.OpGreaterSemver,
+		wireconfig.OpGreaterEqSemver,
 	} {
 		(&opTest{
 			testName: op.String(),
@@ -216,31 +217,31 @@ func TestOpSemverWithString(t *testing.T) {
 
 	tests := []struct {
 		s      string
-		op     operator
+		op     wireconfig.Operator
 		cmpVal string
 		want   bool
 	}{
-		{"1.5.0", opOneOfSemver, "1.5.0", true},
-		{"1.5.0", opOneOfSemver, "1.5.0,1.5.1", true},
-		{"1.5.0", opOneOfSemver, "1.5.1,1.5.2", false},
-		{"1.5.0", opOneOfSemver, "   1.5.0  ,1.5.2   ", true},
-		{"1.5.0", opNotOneOfSemver, "1.5.0", false},
-		{"1.5.0", opNotOneOfSemver, "1.5.0,1.5.1", false},
-		{"1.5.0", opNotOneOfSemver, "1.5.1,1.5.2", true},
-		{"1.5.0", opNotOneOfSemver, "   1.5.0  ,1.5.2   ", false},
-		{"1.4.0", opLessSemver, "1.5.0", true},
-		{"1.4.0", opLessSemver, " 1.5.0 ", true},
-		{"1.4.0", opLessSemver, "1.4.0", false},
-		{"1.4.0", opLessSemver, "1.3.0", false},
-		{"1.4.0", opGreaterSemver, "1.5.0", false},
-		{"1.4.0", opGreaterSemver, "1.4.0", false},
-		{"1.4.0", opGreaterSemver, "1.3.0", true},
-		{"1.4.0", opLessEqSemver, "1.5.0", true},
-		{"1.4.0", opLessEqSemver, "1.4.0", true},
-		{"1.4.0", opLessEqSemver, "1.3.0", false},
-		{"1.4.0", opGreaterEqSemver, "1.5.0", false},
-		{"1.4.0", opGreaterEqSemver, "1.4.0", true},
-		{"1.4.0", opGreaterEqSemver, "1.3.0", true},
+		{"1.5.0", wireconfig.OpOneOfSemver, "1.5.0", true},
+		{"1.5.0", wireconfig.OpOneOfSemver, "1.5.0,1.5.1", true},
+		{"1.5.0", wireconfig.OpOneOfSemver, "1.5.1,1.5.2", false},
+		{"1.5.0", wireconfig.OpOneOfSemver, "   1.5.0  ,1.5.2   ", true},
+		{"1.5.0", wireconfig.OpNotOneOfSemver, "1.5.0", false},
+		{"1.5.0", wireconfig.OpNotOneOfSemver, "1.5.0,1.5.1", false},
+		{"1.5.0", wireconfig.OpNotOneOfSemver, "1.5.1,1.5.2", true},
+		{"1.5.0", wireconfig.OpNotOneOfSemver, "   1.5.0  ,1.5.2   ", false},
+		{"1.4.0", wireconfig.OpLessSemver, "1.5.0", true},
+		{"1.4.0", wireconfig.OpLessSemver, " 1.5.0 ", true},
+		{"1.4.0", wireconfig.OpLessSemver, "1.4.0", false},
+		{"1.4.0", wireconfig.OpLessSemver, "1.3.0", false},
+		{"1.4.0", wireconfig.OpGreaterSemver, "1.5.0", false},
+		{"1.4.0", wireconfig.OpGreaterSemver, "1.4.0", false},
+		{"1.4.0", wireconfig.OpGreaterSemver, "1.3.0", true},
+		{"1.4.0", wireconfig.OpLessEqSemver, "1.5.0", true},
+		{"1.4.0", wireconfig.OpLessEqSemver, "1.4.0", true},
+		{"1.4.0", wireconfig.OpLessEqSemver, "1.3.0", false},
+		{"1.4.0", wireconfig.OpGreaterEqSemver, "1.5.0", false},
+		{"1.4.0", wireconfig.OpGreaterEqSemver, "1.4.0", true},
+		{"1.4.0", wireconfig.OpGreaterEqSemver, "1.3.0", true},
 	}
 	for _, test := range tests {
 		s := test.s
@@ -260,13 +261,13 @@ func TestNoUser(t *testing.T) {
 	ectx := newEvalTestContext(c)
 	(&opTest{
 		testName: "nil-interface",
-		op:       opOneOf,
+		op:       wireconfig.OpOneOf,
 		cmpVal:   "foo",
 		want:     false,
 	}).run(c, ectx, nil)
 	(&opTest{
 		testName: "nil-struct",
-		op:       opOneOf,
+		op:       wireconfig.OpOneOf,
 		cmpVal:   "foo",
 		want:     false,
 	}).run(c, ectx, (*struct{ X string })(nil))
@@ -278,7 +279,7 @@ func TestNonPointerUserStruct(t *testing.T) {
 	ectx := newEvalTestContext(c)
 	(&opTest{
 		testName: "nil-struct",
-		op:       opOneOf,
+		op:       wireconfig.OpOneOf,
 		cmpVal:   "foo",
 		want:     false,
 	}).run(c, ectx, struct{ X string }{})
@@ -325,7 +326,7 @@ func (g *attributeGetter) GetAttribute(attr string) string {
 type opTest struct {
 	testName string
 	// op is the operator to test.
-	op operator
+	op wireconfig.Operator
 	// cmpVal is the argument to the operator.
 	cmpVal string
 	// want holds the expected result of the test.
@@ -336,12 +337,12 @@ func (test *opTest) run(c *qt.C, ectx *evalTestContext, user User) {
 	c.Run(test.testName, func(c *qt.C) {
 		ectx.logger.logFunc = c.Logf
 		c.Logf("operator %v; cmpVal %v; want %v", test.op, test.cmpVal, test.want)
-		ectx.srv.setResponseJSON(&rootNode{
-			Entries: map[string]*entry{
+		ectx.srv.setResponseJSON(&wireconfig.RootNode{
+			Entries: map[string]*wireconfig.Entry{
 				"key": {
 					VariationID: "testFallback",
 					Value:       "false",
-					RolloutRules: []*rolloutRule{{
+					RolloutRules: []*wireconfig.RolloutRule{{
 						ComparisonAttribute: "X",
 						ComparisonValue:     test.cmpVal,
 						Comparator:          test.op,
@@ -369,22 +370,22 @@ func stringOneOfTests(s string) []opTest {
 	}
 	tests := []opTest{{
 		testName: "exact-value",
-		op:       opOneOf,
+		op:       wireconfig.OpOneOf,
 		cmpVal:   s,
 		want:     true,
 	}, {
 		testName: "with-extra-value",
-		op:       opOneOf,
+		op:       wireconfig.OpOneOf,
 		cmpVal:   s + "," + other,
 		want:     true,
 	}, {
 		testName: "with-appended-value",
-		op:       opOneOf,
+		op:       wireconfig.OpOneOf,
 		cmpVal:   s + "x",
 		want:     false,
 	}, {
 		testName: "empty-string",
-		op:       opOneOf,
+		op:       wireconfig.OpOneOf,
 		cmpVal:   "",
 		want:     false,
 	}}
@@ -392,7 +393,7 @@ func stringOneOfTests(s string) []opTest {
 	for _, test := range tests {
 		tests = append(tests, opTest{
 			testName: "not(" + test.testName + ")",
-			op:       opNotOneOf,
+			op:       wireconfig.OpNotOneOf,
 			cmpVal:   test.cmpVal,
 			want:     !test.want,
 		})
@@ -409,7 +410,7 @@ func stringOneOfTests(s string) []opTest {
 // numericCmpNumTests returns a set of tests for the
 // comparison operator op given a User field with value x.
 // cmp reports the result of the comparison operator.
-func numericCmpNumTests(x float64, op operator, cmp func(a, b float64) bool) []opTest {
+func numericCmpNumTests(x float64, op wireconfig.Operator, cmp func(a, b float64) bool) []opTest {
 	if math.IsNaN(x) {
 		return []opTest{{
 			testName: "is-nan",
@@ -482,21 +483,21 @@ func numericOneOfTests(x float64) []opTest {
 	if math.IsNaN(x) {
 		tests = []opTest{{
 			testName: "exact-value-as-float",
-			op:       opOneOf,
+			op:       wireconfig.OpOneOf,
 			cmpVal:   fmt.Sprint(x),
 			want:     false,
 		}}
 	} else {
 		tests = []opTest{{
 			testName: "exact-value-as-float",
-			op:       opOneOf,
+			op:       wireconfig.OpOneOf,
 			cmpVal:   fmt.Sprint(x),
 			want:     true,
 		}}
 		if !math.IsInf(x, 0) {
 			tests = append(tests, opTest{
 				testName: "small-increment",
-				op:       opOneOf,
+				op:       wireconfig.OpOneOf,
 				cmpVal:   fmt.Sprint(addSomethingSmall(x)),
 				want:     false,
 			})
@@ -509,12 +510,12 @@ func numericOneOfTests(x float64) []opTest {
 	for _, test := range tests {
 		tests = append(tests, opTest{
 			testName: test.testName + "-with-extra-elem",
-			op:       opOneOf,
+			op:       wireconfig.OpOneOf,
 			cmpVal:   fmt.Sprint(other) + "," + test.cmpVal,
 			want:     test.want,
 		}, opTest{
 			testName: test.testName + "-with-space",
-			op:       opOneOf,
+			op:       wireconfig.OpOneOf,
 			cmpVal:   " " + test.cmpVal + " ",
 			want:     test.want,
 		})
@@ -523,7 +524,7 @@ func numericOneOfTests(x float64) []opTest {
 	for _, test := range tests {
 		tests = append(tests, opTest{
 			testName: "not(" + test.testName + ")",
-			op:       opNotOneOf,
+			op:       wireconfig.OpNotOneOf,
 			cmpVal:   test.cmpVal,
 			want:     !test.want,
 		})
@@ -620,18 +621,18 @@ func setValueFromFloat(v reflect.Value, f float64) {
 	}
 }
 
-func cmpFunc(op operator) func(a, b float64) bool {
+func cmpFunc(op wireconfig.Operator) func(a, b float64) bool {
 	return func(a, b float64) bool {
 		switch op {
-		case opEqNum:
+		case wireconfig.OpEqNum:
 			return a == b
-		case opLessNum:
+		case wireconfig.OpLessNum:
 			return a < b
-		case opLessEqNum:
+		case wireconfig.OpLessEqNum:
 			return a <= b
-		case opGreaterNum:
+		case wireconfig.OpGreaterNum:
 			return a > b
-		case opGreaterEqNum:
+		case wireconfig.OpGreaterEqNum:
 			return a >= b
 		default:
 			panic(fmt.Errorf("unknown comparison operator %v", op))

--- a/v7/internal/wireconfig/wireconfig.go
+++ b/v7/internal/wireconfig/wireconfig.go
@@ -1,0 +1,113 @@
+// Package wireconfig holds types and constants that define the
+// representation of the ConfigCat configuration as transmitted
+// over the wire from the ConfigCat CDN.
+package wireconfig
+
+type RootNode struct {
+	Entries     map[string]*Entry `json:"f"`
+	Preferences *Preferences      `json:"p"`
+}
+
+type Entry struct {
+	VariationID     string           `json:"i"`
+	Value           interface{}      `json:"v"`
+	Type            EntryType        `json:"t"`
+	RolloutRules    []*RolloutRule   `json:"r"`
+	PercentageRules []PercentageRule `json:"p"`
+}
+
+type RolloutRule struct {
+	VariationID         string      `json:"i"`
+	Value               interface{} `json:"v"`
+	ComparisonAttribute string      `json:"a"`
+	ComparisonValue     string      `json:"c"`
+	Comparator          Operator    `json:"t"`
+}
+
+type PercentageRule struct {
+	VariationID string      `json:"i"`
+	Value       interface{} `json:"v"`
+	Percentage  int64       `json:"p"`
+}
+
+type Preferences struct {
+	URL      string           `json:"u"`
+	Redirect *RedirectionKind `json:"r"` // NoRedirect, ShouldRedirect or ForceRedirect
+}
+
+type RedirectionKind int
+
+const (
+	// Nodirect indicates that the configuration is available
+	// in this request, but that the next request should be
+	// made to the redirected address.
+	Nodirect RedirectionKind = 0
+
+	// ShouldRedirect indicates that there is no configuration
+	// available at this address, and that the client should
+	// redirect immediately. This does not take effect when
+	// talking to a custom URL.
+	ShouldRedirect RedirectionKind = 1
+
+	// ForceRedirect indicates that there is no configuration
+	// available at this address, and that the client should redirect
+	// immediately even when talking to a custom URL.
+	ForceRedirect RedirectionKind = 2
+)
+
+type EntryType int
+
+const (
+	BoolEntry   EntryType = 0
+	StringEntry EntryType = 1
+	IntEntry    EntryType = 2
+	FloatEntry  EntryType = 3
+)
+
+type Operator int
+
+const (
+	OpOneOf             Operator = 0
+	OpNotOneOf          Operator = 1
+	OpContains          Operator = 2
+	OpNotContains       Operator = 3
+	OpOneOfSemver       Operator = 4
+	OpNotOneOfSemver    Operator = 5
+	OpLessSemver        Operator = 6
+	OpLessEqSemver      Operator = 7
+	OpGreaterSemver     Operator = 8
+	OpGreaterEqSemver   Operator = 9
+	OpEqNum             Operator = 10
+	OpNotEqNum          Operator = 11
+	OpLessNum           Operator = 12
+	OpLessEqNum         Operator = 13
+	OpGreaterNum        Operator = 14
+	OpGreaterEqNum      Operator = 15
+	OpOneOfSensitive    Operator = 16
+	OpNotOneOfSensitive Operator = 17
+)
+
+var opStrings = []string{
+	OpOneOf:             "IS ONE OF",
+	OpNotOneOf:          "IS NOT ONE OF",
+	OpContains:          "CONTAINS",
+	OpNotContains:       "DOES NOT CONTAIN",
+	OpOneOfSemver:       "IS ONE OF (SemVer)",
+	OpNotOneOfSemver:    "IS NOT ONE OF (SemVer)",
+	OpLessSemver:        "< (SemVer)",
+	OpLessEqSemver:      "<= (SemVer)",
+	OpGreaterSemver:     "> (SemVer)",
+	OpGreaterEqSemver:   ">= (SemVer)",
+	OpEqNum:             "= (Number)",
+	OpNotEqNum:          "<> (Number)",
+	OpLessNum:           "< (Number)",
+	OpLessEqNum:         "<= (Number)",
+	OpGreaterNum:        "> (Number)",
+	OpGreaterEqNum:      ">= (Number)",
+	OpOneOfSensitive:    "IS ONE OF (Sensitive)",
+	OpNotOneOfSensitive: "IS NOT ONE OF (Sensitive)",
+}
+
+func (op Operator) String() string {
+	return opStrings[op]
+}

--- a/v7/lazy_loading_policy_test.go
+++ b/v7/lazy_loading_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp"
 )
@@ -12,7 +13,7 @@ import (
 func TestLazyLoadingPolicy_NoAsync(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
-	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1", stringEntry))
+	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1", wireconfig.StringEntry))
 
 	cfg := srv.config()
 	cfg.PollingMode = Lazy
@@ -23,7 +24,7 @@ func TestLazyLoadingPolicy_NoAsync(t *testing.T) {
 	c.Assert(client.GetStringValue("key", "", nil), qt.Equals, "value1")
 
 	srv.setResponse(configResponse{
-		body:  marshalJSON(rootNodeWithKeyValue("key", "value2", stringEntry)),
+		body:  marshalJSON(rootNodeWithKeyValue("key", "value2", wireconfig.StringEntry)),
 		sleep: 40 * time.Millisecond,
 	})
 	c.Assert(client.GetStringValue("key", "", nil), qt.Equals, "value1")
@@ -52,7 +53,7 @@ func TestLazyLoadingPolicy_FetchFail(t *testing.T) {
 func TestLazyLoadingPolicy_Async(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
-	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1", stringEntry))
+	srv.setResponseJSON(rootNodeWithKeyValue("key", "value1", wireconfig.StringEntry))
 
 	cfg := srv.config()
 	cfg.PollingMode = Lazy
@@ -67,7 +68,7 @@ func TestLazyLoadingPolicy_Async(t *testing.T) {
 	c.Assert(client.GetStringValue("key", "", nil), qt.Equals, "value1")
 
 	srv.setResponse(configResponse{
-		body:  marshalJSON(rootNodeWithKeyValue("key", "value2", stringEntry)),
+		body:  marshalJSON(rootNodeWithKeyValue("key", "value2", wireconfig.StringEntry)),
 		sleep: 40 * time.Millisecond,
 	})
 	c.Assert(client.GetStringValue("key", "", nil), qt.Equals, "value1")

--- a/v7/snapshot_test.go
+++ b/v7/snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 	qt "github.com/frankban/quicktest"
 )
 
@@ -28,14 +29,14 @@ func TestNilSnapshot(t *testing.T) {
 
 var loggingTests = []struct {
 	testName    string
-	config      *rootNode
+	config      *wireconfig.RootNode
 	key         string
 	user        User
 	expectValue interface{}
 	expectLogs  []string
 }{{
 	testName:    "NoRules",
-	config:      rootNodeWithKeyValue("key", "value", stringEntry),
+	config:      rootNodeWithKeyValue("key", "value", wireconfig.StringEntry),
 	key:         "key",
 	expectValue: "value",
 	expectLogs: []string{
@@ -44,16 +45,16 @@ var loggingTests = []struct {
 	},
 }, {
 	testName: "RolloutRulesButNoUser",
-	config: &rootNode{
-		Entries: map[string]*entry{
+	config: &wireconfig.RootNode{
+		Entries: map[string]*wireconfig.Entry{
 			"key": {
 				Value: "defaultValue",
-				Type:  stringEntry,
-				RolloutRules: []*rolloutRule{{
+				Type:  wireconfig.StringEntry,
+				RolloutRules: []*wireconfig.RolloutRule{{
 					Value:               "e",
 					ComparisonAttribute: "attr",
 					ComparisonValue:     "x",
-					Comparator:          opContains,
+					Comparator:          wireconfig.OpContains,
 				}},
 			},
 		},
@@ -67,20 +68,20 @@ var loggingTests = []struct {
 	},
 }, {
 	testName: "RolloutRulesWithUser",
-	config: &rootNode{
-		Entries: map[string]*entry{
+	config: &wireconfig.RootNode{
+		Entries: map[string]*wireconfig.Entry{
 			"key": {
 				Value: "defaultValue",
-				Type:  stringEntry,
-				RolloutRules: []*rolloutRule{{
+				Type:  wireconfig.StringEntry,
+				RolloutRules: []*wireconfig.RolloutRule{{
 					Value:               "v1",
 					ComparisonAttribute: "Identifier",
-					Comparator:          opContains,
+					Comparator:          wireconfig.OpContains,
 					ComparisonValue:     "x",
 				}, {
 					Value:               "v2",
 					ComparisonAttribute: "Identifier",
-					Comparator:          opContains,
+					Comparator:          wireconfig.OpContains,
 					ComparisonValue:     "y",
 				}},
 			},
@@ -99,12 +100,12 @@ var loggingTests = []struct {
 	},
 }, {
 	testName: "PercentageRulesButNoUser",
-	config: &rootNode{
-		Entries: map[string]*entry{
+	config: &wireconfig.RootNode{
+		Entries: map[string]*wireconfig.Entry{
 			"key": {
 				Value: "defaultValue",
-				Type:  stringEntry,
-				PercentageRules: []percentageRule{{
+				Type:  wireconfig.StringEntry,
+				PercentageRules: []wireconfig.PercentageRule{{
 					Value:      "low-percent",
 					Percentage: 30,
 				}, {
@@ -123,12 +124,12 @@ var loggingTests = []struct {
 	},
 }, {
 	testName: "PercentageRulesWithUser",
-	config: &rootNode{
-		Entries: map[string]*entry{
+	config: &wireconfig.RootNode{
+		Entries: map[string]*wireconfig.Entry{
 			"key": {
 				Value: "defaultValue",
-				Type:  stringEntry,
-				PercentageRules: []percentageRule{{
+				Type:  wireconfig.StringEntry,
+				PercentageRules: []wireconfig.PercentageRule{{
 					Value:      "low-percent",
 					Percentage: 1,
 				}, {
@@ -149,16 +150,16 @@ var loggingTests = []struct {
 	},
 }, {
 	testName: "MatchErrorInUser",
-	config: &rootNode{
-		Entries: map[string]*entry{
+	config: &wireconfig.RootNode{
+		Entries: map[string]*wireconfig.Entry{
 			"key": {
 				Value: "defaultValue",
-				Type:  stringEntry,
-				RolloutRules: []*rolloutRule{{
+				Type:  wireconfig.StringEntry,
+				RolloutRules: []*wireconfig.RolloutRule{{
 					Value:               "e",
 					ComparisonAttribute: "Identifier",
 					ComparisonValue:     "1.2.3",
-					Comparator:          opLessSemver,
+					Comparator:          wireconfig.OpLessSemver,
 				}},
 			},
 		},
@@ -175,16 +176,16 @@ var loggingTests = []struct {
 	},
 }, {
 	testName: "MatchErrorRules",
-	config: &rootNode{
-		Entries: map[string]*entry{
+	config: &wireconfig.RootNode{
+		Entries: map[string]*wireconfig.Entry{
 			"key": {
 				Value: "defaultValue",
-				Type:  stringEntry,
-				RolloutRules: []*rolloutRule{{
+				Type:  wireconfig.StringEntry,
+				RolloutRules: []*wireconfig.RolloutRule{{
 					Value:               "e",
 					ComparisonAttribute: "Identifier",
 					ComparisonValue:     "bogus",
-					Comparator:          opLessSemver,
+					Comparator:          wireconfig.OpLessSemver,
 				}},
 			},
 		},
@@ -201,15 +202,15 @@ var loggingTests = []struct {
 	},
 }, {
 	testName: "UnknownKey",
-	config: &rootNode{
-		Entries: map[string]*entry{
+	config: &wireconfig.RootNode{
+		Entries: map[string]*wireconfig.Entry{
 			"key1": {
 				Value: "v1",
-				Type:  stringEntry,
+				Type:  wireconfig.StringEntry,
 			},
 			"key2": {
 				Value: "v2",
-				Type:  stringEntry,
+				Type:  wireconfig.StringEntry,
 			},
 		},
 	},


### PR DESCRIPTION
As a preparatory step for a `fakeconfigcat` package, this
PR factors out the relevant wire structs into their own
package so that they can be imported without the
need to expose them in the public API.

The changes were made automatically by running
the following [rf](https://rsc.io/rf) command:

```
rf '
	mv rootNode RootNode
	mv entryType EntryType
	mv preferences Preferences
	mv percentageRule PercentageRule
	mv operator Operator
	mv redirectionKind RedirectionKind
	mv rolloutRule RolloutRule
	mv entry Entry

	mv boolEntry BoolEntry
	mv stringEntry  StringEntry
	mv intEntry IntEntry
	mv floatEntry FloatEntry

	mv opOneOf OpOneOf
	mv opNotOneOf OpNotOneOf
	mv opContains OpContains
	mv opNotContains OpNotContains
	mv opOneOfSemver OpOneOfSemver
	mv opNotOneOfSemver OpNotOneOfSemver
	mv opLessSemver OpLessSemver
	mv opLessEqSemver OpLessEqSemver
	mv opGreaterSemver OpGreaterSemver
	mv opGreaterEqSemver OpGreaterEqSemver
	mv opEqNum OpEqNum
	mv opNotEqNum OpNotEqNum
	mv opLessNum OpLessNum
	mv opLessEqNum OpLessEqNum
	mv opGreaterNum OpGreaterNum
	mv opGreaterEqNum OpGreaterEqNum
	mv opOneOfSensitive OpOneOfSensitive
	mv opNotOneOfSensitive OpNotOneOfSensitive

	mv noRedirect Nodirect
	mv shouldRedirect ShouldRedirect
	mv forceRedirect ForceRedirect
	mv wireconfig.go github.com/configcat/go-sdk/v7/internal/wireconfig
```

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
