### PR TITLE
configcat/configcattest: new package

### DIFF
--- a/v7/configcattest/doc.go
+++ b/v7/configcattest/doc.go
@@ -1,0 +1,6 @@
+// Package configcattest provides an HTTP handler that
+// can be used to test configcat scenarios in tests.
+//
+// This API should be considered experimental for now and may change
+// in a backwardly incompatible manner.
+package configcattest

--- a/v7/configcattest/flag.go
+++ b/v7/configcattest/flag.go
@@ -1,0 +1,72 @@
+package configcattest
+
+import (
+	"fmt"
+
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
+)
+
+// Flag represents a configcat flag.
+type Flag struct {
+	// Default holds the default value for the flag.
+	// It should hold one of the types string, float64, int or bool.
+	Default interface{}
+
+	// Rules holds a set of rules to check against in order.
+	// If any rule is satisfied, its associated value is used,
+	// otherwise the default value is used.
+	Rules []Rule
+}
+
+type Rule struct {
+	// ComparisonAttribute holds the user attribute to
+	// check when evaluating the rule.
+	ComparisonAttribute string
+
+	// Comparator holds how the compare the above user
+	// attribute to the comparison value.
+	Comparator Operator
+
+	// ComparisonValue holds the value to compare the
+	// user attribute against.
+	ComparisonValue string
+
+	// Value holds the value for the flag if the rule is satisfied.
+	// It should hold one of the types string, float64, int or bool
+	// and be the same type as the default value of the
+	// flag that it's associated with.
+	Value interface{}
+}
+
+func (f *Flag) entry() (*wireconfig.Entry, error) {
+	ft := typeOf(f.Default)
+	if ft == invalidEntry {
+		return nil, fmt.Errorf("invalid type %T for default value %#v", f.Default, f.Default)
+	}
+	e := &wireconfig.Entry{
+		Type:         ft,
+		Value:        f.Default,
+		RolloutRules: make([]*wireconfig.RolloutRule, 0, len(f.Rules)),
+	}
+	for _, rule := range f.Rules {
+		if rule.Comparator.String() == "" {
+			return nil, fmt.Errorf("invalid comparator value %d", rule.Comparator)
+		}
+		if rule.ComparisonAttribute == "" {
+			return nil, fmt.Errorf("empty comparison attribute")
+		}
+		if rule.ComparisonValue == "" {
+			return nil, fmt.Errorf("empty comparison value")
+		}
+		if typeOf(rule.Value) != ft {
+			return nil, fmt.Errorf("rule value for rule (%q %v %q) has inconsistent type %T (value %#v) with flag default value %#v", rule.ComparisonAttribute, rule.Comparator, rule.ComparisonValue, rule.Value, rule.Value, f.Default)
+		}
+		e.RolloutRules = append(e.RolloutRules, &wireconfig.RolloutRule{
+			Value:               rule.Value,
+			ComparisonAttribute: rule.ComparisonAttribute,
+			Comparator:          wireconfig.Operator(rule.Comparator),
+			ComparisonValue:     rule.ComparisonValue,
+		})
+	}
+	return e, nil
+}

--- a/v7/configcattest/handler.go
+++ b/v7/configcattest/handler.go
@@ -1,0 +1,105 @@
+// Package configcattest provides an HTTP handler that
+// can be used to test configcat scenarios in tests.
+package configcattest
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
+)
+
+// Handler is an http.Handler that serves up configcat flags.
+// The zero value is OK to use and has no flag configurations.
+// Use SetFlags to add or update the set of flags served.
+type Handler struct {
+	mu       sync.Mutex
+	contents map[string][]byte
+}
+
+// ServeHTTP implements http.Handler.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		http.Error(w, "only GET is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	h.mu.Lock()
+	content := h.contents[req.URL.Path]
+	h.mu.Unlock()
+	if content == nil {
+		http.NotFound(w, req)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(content)
+}
+
+// SetFlags sets or updates the flags served by the handler for the
+// given SDK key. It can be called concurrently with other Handler methods.
+//
+// Use RandomSDKKey to create a new SDK key.
+func (h *Handler) SetFlags(sdkKey string, flags map[string]*Flag) error {
+	if sdkKey == "" {
+		return fmt.Errorf("empty SDK key passed to configcattest.Handler.SetFlags")
+	}
+	data, err := makeContent(flags)
+	if err != nil {
+		return err
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.contents == nil {
+		h.contents = make(map[string][]byte)
+	}
+	h.contents["/configuration-files/"+sdkKey+"/config_v5.json"] = data
+	return nil
+}
+
+func makeContent(flags map[string]*Flag) ([]byte, error) {
+	root := &wireconfig.RootNode{
+		Entries: make(map[string]*wireconfig.Entry, len(flags)),
+	}
+	for name, flag := range flags {
+		e, err := flag.entry()
+		if err != nil {
+			return nil, fmt.Errorf("invalid flag %q: %v", name, err)
+		}
+		root.Entries[name] = e
+	}
+	data, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal configuration: %v", err)
+	}
+	return data, nil
+}
+
+// RandomSDKKey returns a new randomly generated SDK key
+// suitable for passing to SetFlags.
+func RandomSDKKey() string {
+	var k sdkKey
+	if _, err := rand.Read(k.org[:]); err != nil {
+		panic(err)
+	}
+	if _, err := rand.Read(k.product[:]); err != nil {
+		panic(err)
+	}
+	return k.String()
+}
+
+type sdkKey struct {
+	org, product [16]byte
+}
+
+func (k sdkKey) String() string {
+	enc := base64.RawURLEncoding
+	n := enc.EncodedLen(len(k.org))
+	b := make([]byte, n*2+1)
+	enc.Encode(b, k.org[:])
+	b[n] = '/'
+	enc.Encode(b[n+1:], k.product[:])
+	return string(b)
+}

--- a/v7/configcattest/handler_test.go
+++ b/v7/configcattest/handler_test.go
@@ -1,0 +1,196 @@
+package configcattest_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	configcat "github.com/configcat/go-sdk/v7"
+	"github.com/configcat/go-sdk/v7/configcattest"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestHandlerSimple(t *testing.T) {
+	c := qt.New(t)
+	k := configcattest.RandomSDKKey()
+	var h configcattest.Handler
+	err := h.SetFlags(k, map[string]*configcattest.Flag{
+		"intflag": {
+			Default: 99,
+		},
+		"floatflag": {
+			Default: 100.0,
+		},
+		"stringflag": {
+			Default: "s",
+		},
+		"boolflag": {
+			Default: true,
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	srv := httptest.NewServer(&h)
+	defer srv.Close()
+	client := configcat.NewCustomClient(configcat.Config{
+		BaseURL: srv.URL,
+		SDKKey:  k,
+	})
+	defer client.Close()
+	c.Assert(configcat.Int("intflag", 1).Get(client.Snapshot(nil)), qt.Equals, 99)
+	c.Assert(configcat.Int("otherflag", 1).Get(client.Snapshot(nil)), qt.Equals, 1)
+
+	c.Assert(configcat.Float("floatflag", 1.0).Get(client.Snapshot(nil)), qt.Equals, 100.0)
+	c.Assert(configcat.String("stringflag", "").Get(client.Snapshot(nil)), qt.Equals, "s")
+	c.Assert(configcat.Bool("boolflag", false).Get(client.Snapshot(nil)), qt.Equals, true)
+}
+
+func TestHandlerWithUser(t *testing.T) {
+	c := qt.New(t)
+	k := configcattest.RandomSDKKey()
+	var h configcattest.Handler
+	err := h.SetFlags(k, map[string]*configcattest.Flag{
+		"someflag": {
+			Default: 99,
+			Rules: []configcattest.Rule{{
+				ComparisonAttribute: "foo",
+				Comparator:          configcattest.OpOneOf,
+				ComparisonValue:     "something",
+				Value:               88,
+			}, {
+				ComparisonAttribute: "foo",
+				Comparator:          configcattest.OpContains,
+				ComparisonValue:     "xxx",
+				Value:               77,
+			}},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	srv := httptest.NewServer(&h)
+	defer srv.Close()
+	client := configcat.NewCustomClient(configcat.Config{
+		BaseURL: srv.URL,
+		SDKKey:  k,
+	})
+	defer client.Close()
+	flag := configcat.Int("someflag", 1)
+	c.Assert(flag.Get(client.Snapshot(nil)), qt.Equals, 99)
+
+	type user struct {
+		Foo string `configcat:"foo"`
+	}
+	c.Assert(flag.Get(client.Snapshot(&user{
+		Foo: "something",
+	})), qt.Equals, 88)
+	c.Assert(flag.Get(client.Snapshot(&user{
+		Foo: "blahxxxblah",
+	})), qt.Equals, 77)
+	c.Assert(flag.Get(client.Snapshot(&user{
+		Foo: "other",
+	})), qt.Equals, 99)
+}
+
+var invalidFlagsTests = []struct {
+	testName    string
+	flag        *configcattest.Flag
+	expectError string
+}{{
+	testName: "InvalidDefault",
+	flag: &configcattest.Flag{
+		Default: byte(1),
+	},
+	expectError: `invalid flag "foo": invalid type uint8 for default value 0x1`,
+}, {
+	testName: "InvalidComparator",
+	flag: &configcattest.Flag{
+		Default: 1,
+		Rules: []configcattest.Rule{{
+			ComparisonAttribute: "x",
+			Comparator:          200,
+			ComparisonValue:     "y",
+			Value:               2,
+		}},
+	},
+	expectError: `invalid flag "foo": invalid comparator value 200`,
+}, {
+	testName: "EmptyComparisonAttribute",
+	flag: &configcattest.Flag{
+		Default: 1,
+		Rules: []configcattest.Rule{{
+			ComparisonAttribute: "",
+			Comparator:          configcattest.OpContains,
+			ComparisonValue:     "y",
+			Value:               2,
+		}},
+	},
+	expectError: `invalid flag "foo": empty comparison attribute`,
+}, {
+	testName: "EmptyComparisonAttribute",
+	flag: &configcattest.Flag{
+		Default: 1,
+		Rules: []configcattest.Rule{{
+			ComparisonAttribute: "x",
+			Comparator:          configcattest.OpContains,
+			ComparisonValue:     "",
+		}},
+	},
+	expectError: `invalid flag "foo": empty comparison value`,
+}, {
+	testName: "InconsistentRuleType",
+	flag: &configcattest.Flag{
+		Default: 1,
+		Rules: []configcattest.Rule{{
+			ComparisonAttribute: "x",
+			Comparator:          configcattest.OpContains,
+			ComparisonValue:     "y",
+			Value:               "x",
+		}},
+	},
+	expectError: `invalid flag "foo": rule value for rule \("x" CONTAINS "y"\) has inconsistent type string \(value "x"\) with flag default value 1`,
+}}
+
+func TestInvalidFlags(t *testing.T) {
+	c := qt.New(t)
+	k := configcattest.RandomSDKKey()
+	for _, test := range invalidFlagsTests {
+		c.Run(test.testName, func(c *qt.C) {
+			var h configcattest.Handler
+			err := h.SetFlags(k, map[string]*configcattest.Flag{
+				"foo": test.flag,
+			})
+			c.Assert(err, qt.ErrorMatches, test.expectError)
+		})
+	}
+}
+
+func TestHandlerAddInvalidSDKKey(t *testing.T) {
+	c := qt.New(t)
+	var h configcattest.Handler
+	err := h.SetFlags("", nil)
+	c.Assert(err, qt.ErrorMatches, `empty SDK key passed to configcattest.Handler.SetFlags`)
+}
+
+func TestHandlerSDKKeyNotFound(t *testing.T) {
+	c := qt.New(t)
+	var h configcattest.Handler
+	srv := httptest.NewServer(&h)
+	defer srv.Close()
+	client := configcat.NewCustomClient(configcat.Config{
+		BaseURL: srv.URL,
+		SDKKey:  configcattest.RandomSDKKey(),
+	})
+	defer client.Close()
+	c.Assert(configcat.Int("i", 20).Get(client.Snapshot(nil)), qt.Equals, 20)
+}
+
+func TestHandlerWrongMethod(t *testing.T) {
+	c := qt.New(t)
+	var h configcattest.Handler
+	srv := httptest.NewServer(&h)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL, "", strings.NewReader("x"))
+	c.Assert(err, qt.IsNil)
+	resp.Body.Close()
+	c.Assert(resp.StatusCode, qt.Equals, http.StatusMethodNotAllowed)
+}

--- a/v7/configcattest/operator.go
+++ b/v7/configcattest/operator.go
@@ -1,0 +1,47 @@
+package configcattest
+
+import "github.com/configcat/go-sdk/v7/internal/wireconfig"
+
+// Operator defines a comparison operator.
+type Operator wireconfig.Operator
+
+const (
+	OpOneOf             = Operator(wireconfig.OpOneOf)
+	OpNotOneOf          = Operator(wireconfig.OpNotOneOf)
+	OpContains          = Operator(wireconfig.OpContains)
+	OpNotContains       = Operator(wireconfig.OpNotContains)
+	OpOneOfSemver       = Operator(wireconfig.OpOneOfSemver)
+	OpNotOneOfSemver    = Operator(wireconfig.OpNotOneOfSemver)
+	OpLessSemver        = Operator(wireconfig.OpLessSemver)
+	OpLessEqSemver      = Operator(wireconfig.OpLessEqSemver)
+	OpGreaterSemver     = Operator(wireconfig.OpGreaterSemver)
+	OpGreaterEqSemver   = Operator(wireconfig.OpGreaterEqSemver)
+	OpEqNum             = Operator(wireconfig.OpEqNum)
+	OpNotEqNum          = Operator(wireconfig.OpNotEqNum)
+	OpLessNum           = Operator(wireconfig.OpLessNum)
+	OpLessEqNum         = Operator(wireconfig.OpLessEqNum)
+	OpGreaterNum        = Operator(wireconfig.OpGreaterNum)
+	OpGreaterEqNum      = Operator(wireconfig.OpGreaterEqNum)
+	OpOneOfSensitive    = Operator(wireconfig.OpOneOfSensitive)
+	OpNotOneOfSensitive = Operator(wireconfig.OpNotOneOfSensitive)
+)
+
+func (op Operator) String() string {
+	return wireconfig.Operator(op).String()
+}
+
+const invalidEntry wireconfig.EntryType = -1
+
+func typeOf(x interface{}) wireconfig.EntryType {
+	switch x.(type) {
+	case string:
+		return wireconfig.StringEntry
+	case int:
+		return wireconfig.IntEntry
+	case float64:
+		return wireconfig.FloatEntry
+	case bool:
+		return wireconfig.BoolEntry
+	}
+	return invalidEntry
+}

--- a/v7/internal/wireconfig/wireconfig.go
+++ b/v7/internal/wireconfig/wireconfig.go
@@ -109,5 +109,8 @@ var opStrings = []string{
 }
 
 func (op Operator) String() string {
+	if op < 0 || int(op) >= len(opStrings) {
+		return ""
+	}
 	return opStrings[op]
 }


### PR DESCRIPTION
This makes it simple to set up a fake configcat server for testing purposes.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.

