### PR TITLE
v7: evaluate any rule at most once

### DIFF
--- a/v7/config_fetcher.go
+++ b/v7/config_fetcher.go
@@ -206,7 +206,7 @@ func (f *configFetcher) fetchConfig(ctx context.Context, baseURL string, prevCon
 		f.logger.Debugf("empty config text in cache")
 		return nil, "", err
 	}
-	cfg, cacheErr = parseConfig(configText, "", time.Time{})
+	cfg, cacheErr = parseConfig(configText, "", time.Time{}, f.logger)
 	if cacheErr != nil {
 		f.logger.Errorf("cache contained invalid config: %v", err)
 		return nil, "", err
@@ -313,7 +313,7 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 		if err != nil {
 			return nil, fmt.Errorf("config fetch read failed: %v", err)
 		}
-		config, err := parseConfig(body, response.Header.Get("Etag"), time.Now())
+		config, err := parseConfig(body, response.Header.Get("Etag"), time.Now(), f.logger)
 		if err != nil {
 			return nil, fmt.Errorf("config fetch returned invalid body: %v", err)
 		}

--- a/v7/internal/wireconfig/wireconfig.go
+++ b/v7/internal/wireconfig/wireconfig.go
@@ -14,6 +14,8 @@ type Entry struct {
 	Type            EntryType         `json:"t"`
 	RolloutRules    []*RolloutRule    `json:"r"`
 	PercentageRules []*PercentageRule `json:"p"`
+
+	ValueID int32 `json:"-"`
 }
 
 type RolloutRule struct {
@@ -22,12 +24,16 @@ type RolloutRule struct {
 	ComparisonAttribute string      `json:"a"`
 	ComparisonValue     string      `json:"c"`
 	Comparator          Operator    `json:"t"`
+
+	ValueID int32 `json:"-"`
 }
 
 type PercentageRule struct {
 	VariationID string      `json:"i"`
 	Value       interface{} `json:"v"`
 	Percentage  int64       `json:"p"`
+
+	ValueID int32 `json:"-"`
 }
 
 type Preferences struct {

--- a/v7/rollout_integration_test.go
+++ b/v7/rollout_integration_test.go
@@ -166,7 +166,7 @@ func (test integrationTestSuite) runTests(t *testing.T, integration bool, logLev
 		srv.setResponse(configResponse{body: contentForIntegrationTestKey(test.sdkKey)})
 		cfg = srv.config()
 	}
-	tlogger := newTestLogger(t, LogLevelDebug).(*testLogger)
+	tlogger := newTestLogger(t, logLevel).(*testLogger)
 	cfg.Logger = tlogger
 	cfg.SDKKey = test.sdkKey
 	client := NewCustomClient(cfg)

--- a/v7/snapshot_test.go
+++ b/v7/snapshot_test.go
@@ -92,7 +92,7 @@ var loggingTests = []struct {
 	expectValue: "v2",
 	expectLogs: []string{
 		"INFO: Evaluating rule: [Identifier:y] [CONTAINS] [x] => no match",
-		"INFO: Evaluating rule: [Identifier:y] [CONTAINS] [y] => match, returning: v2",
+		"INFO: Evaluating rule: [Identifier:y] [CONTAINS] [y] => match",
 		"INFO: Returning key=v2.",
 	},
 }, {

--- a/v7/user.go
+++ b/v7/user.go
@@ -2,7 +2,10 @@ package configcat
 
 // The User interface represents the user-specific data that can influence
 // configcat rule evaluation. All Users are expected to provide an Identifier
-// attribute.
+// attribute. A User value is assumed to be immutable once it's been
+// provided to configcat - if it changes between feature flag evaluations,
+// there's no guarantee that the feature flag results will change accordingly
+// (use WithUser instead of mutating the value).
 //
 // The configcat client uses reflection to determine
 // what attributes are available:


### PR DESCRIPTION
This optimization means that complex rules will only be evaluated once
for any given config/user combination - the previous result is used when
possible.

We also make it clear that a User value is intended to be unchanging,
and fix an issue with int-values in percentage rules where they
could return a float64 instead of an int.

Any values that can be computed when the configuration is parsed
are stored then; any that cannot are stored in a slice, created on demand,
that's only as large as it needs to be, and only on demand, which means
that in the common case where the only flags inspected have no rollout
rules, this will be quite efficient.

As a special case when the configuration is parsed, we also compute
the snapshot for the no-user case. This is particularly helpful for long-running
goroutines that aren't servicing a user request because in that case
there's generally no good way to keep a snapshot around for the duration
of a request, and hence the `Client.Snapshot` cost is dominant.
Also, having a single snapshot instance for this case means the cached
calculated values can be shared between all goroutines that use `Client.Snapshot(nil)`.
This improvement is measured by the `Get/no-user/get-and-make` benchmark.
I've also included a benchmark for the likely-common case of getting a value
from a snapshot for a flag with no rollout rules.

The benchmarks show modest cost in some places, but very significant improvement
in others.

```
name                                   old time/op    new time/op    delta
Get/one-of/get-and-make-8                 166ns ± 1%     245ns ± 1%   +47.59%  (p=0.008 n=5+5)
Get/one-of/get-only-8                    64.4ns ± 1%     7.5ns ± 3%   -88.43%  (p=0.008 n=5+5)
Get/less-than-with-int/get-and-make-8     122ns ± 1%     201ns ± 1%   +65.04%  (p=0.008 n=5+5)
Get/less-than-with-int/get-only-8        22.8ns ± 1%     7.4ns ± 0%   -67.53%  (p=0.008 n=5+5)
Get/with-percentage/get-and-make-8        417ns ± 0%     492ns ± 0%   +17.97%  (p=0.008 n=5+5)
Get/with-percentage/get-only-8            312ns ± 1%       7ns ± 2%   -97.61%  (p=0.008 n=5+5)
Get/no-rules/get-and-make-8               106ns ± 0%     118ns ± 0%   +11.91%  (p=0.008 n=5+5)
Get/no-rules/get-only-8                  14.7ns ± 5%     4.4ns ± 3%   -70.15%  (p=0.008 n=5+5)
Get/no-user/get-and-make-8               91.7ns ± 0%    10.6ns ± 0%   -88.41%  (p=0.008 n=5+5)
Get/no-user/get-only-8                   8.03ns ± 3%    7.38ns ± 1%    -8.11%  (p=0.008 n=5+5)
NewSnapshot-8                            8.06µs ± 1%    8.01µs ± 1%      ~     (p=0.151 n=5+5)

name                                   old alloc/op   new alloc/op   delta
Get/one-of/get-and-make-8                 96.0B ± 0%    180.0B ± 0%   +87.50%  (p=0.008 n=5+5)
Get/one-of/get-only-8                     0.00B          0.00B           ~     (all equal)
Get/less-than-with-int/get-and-make-8     96.0B ± 0%    180.0B ± 0%   +87.50%  (p=0.008 n=5+5)
Get/less-than-with-int/get-only-8         0.00B          0.00B           ~     (all equal)
Get/with-percentage/get-and-make-8         168B ± 0%      252B ± 0%   +50.00%  (p=0.008 n=5+5)
Get/with-percentage/get-only-8            72.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Get/no-rules/get-and-make-8               96.0B ± 0%    176.0B ± 0%   +83.33%  (p=0.008 n=5+5)
Get/no-rules/get-only-8                   0.00B          0.00B           ~     (all equal)
Get/no-user/get-and-make-8                96.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
Get/no-user/get-only-8                    0.00B          0.00B           ~     (all equal)
NewSnapshot-8                            4.63kB ± 0%    5.10kB ± 0%   +10.02%  (p=0.008 n=5+5)

name                                   old allocs/op  new allocs/op  delta
Get/one-of/get-and-make-8                  1.00 ± 0%      2.00 ± 0%  +100.00%  (p=0.008 n=5+5)
Get/one-of/get-only-8                      0.00           0.00           ~     (all equal)
Get/less-than-with-int/get-and-make-8      1.00 ± 0%      2.00 ± 0%  +100.00%  (p=0.008 n=5+5)
Get/less-than-with-int/get-only-8          0.00           0.00           ~     (all equal)
Get/with-percentage/get-and-make-8         3.00 ± 0%      4.00 ± 0%   +33.33%  (p=0.008 n=5+5)
Get/with-percentage/get-only-8             2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Get/no-rules/get-and-make-8                1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Get/no-rules/get-only-8                    0.00           0.00           ~     (all equal)
Get/no-user/get-and-make-8                 1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Get/no-user/get-only-8                     0.00           0.00           ~     (all equal)
NewSnapshot-8                              6.00 ± 0%      6.00 ± 0%      ~     (all equal)
```

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
