### PR TITLE
v7: better tests

### DIFF
--- a/v7/benchmark_test.go
+++ b/v7/benchmark_test.go
@@ -92,7 +92,7 @@ func BenchmarkGet(b *testing.B) {
 						VariationID:         "385d9803",
 						Value:               "country-match",
 					}},
-					PercentageRules: []wireconfig.PercentageRule{{
+					PercentageRules: []*wireconfig.PercentageRule{{
 						VariationID: "607147d5",
 						Value:       "low-percent",
 						Percentage:  30,

--- a/v7/internal/wireconfig/wireconfig.go
+++ b/v7/internal/wireconfig/wireconfig.go
@@ -9,11 +9,11 @@ type RootNode struct {
 }
 
 type Entry struct {
-	VariationID     string           `json:"i"`
-	Value           interface{}      `json:"v"`
-	Type            EntryType        `json:"t"`
-	RolloutRules    []*RolloutRule   `json:"r"`
-	PercentageRules []PercentageRule `json:"p"`
+	VariationID     string            `json:"i"`
+	Value           interface{}       `json:"v"`
+	Type            EntryType         `json:"t"`
+	RolloutRules    []*RolloutRule    `json:"r"`
+	PercentageRules []*PercentageRule `json:"p"`
 }
 
 type RolloutRule struct {


### PR DESCRIPTION
In preparation for the performance improvements in #46,
this PR updates the tests to test more aspects of the implementation.

One notable change is that the type of the "expected" value in the integration
tests is no longer derived from the value received by the implementation.
Unfortunately the test data does not specifically say what type is
expected, but in practice it's always specific enough that we can
determine the type (in particular floating point numbers always have
a decimal point and booleans are always formatted as `True` or `False`.

This change exposed an issue with the percentage rule value fixup which
meant that the values weren't being updated, which is now fixed.

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
