### PR TITLE
v7: implement GetValue method on flags

### DIFF
--- a/v7/flag.go
+++ b/v7/flag.go
@@ -4,6 +4,16 @@ import (
 	"sync"
 )
 
+// Flag is the interface implemented by all flag types.
+type Flag interface {
+	// Key returns the flag's key.
+	Key() string
+
+	// GetValue returns the flag's value. It will always
+	// return the appropriate type for the flag (never nil).
+	GetValue(snap *Snapshot) interface{}
+}
+
 // Bool returns a representation of a boolean-valued flag.
 // This can to be used as the value of a global variable
 // for a specific flag; for example:
@@ -23,10 +33,12 @@ func Bool(key string, defaultValue bool) BoolFlag {
 	}
 }
 
+var _ Flag = BoolFlag{}
+
 type BoolFlag struct {
 	id           keyID
 	key          string
-	defaultValue bool
+	defaultValue interface{}
 }
 
 // Key returns the name of the flag as passed to Bool.
@@ -38,7 +50,13 @@ func (f BoolFlag) Key() string {
 // given snapshot. It returns the flag's default value if snap is nil
 // or the key isn't in the configuration.
 func (f BoolFlag) Get(snap *Snapshot) bool {
-	if v, ok := snap.value(f.id, f.key).(bool); ok {
+	return f.GetValue(snap).(bool)
+}
+
+// GetValue implements Flag.GetValue.
+func (f BoolFlag) GetValue(snap *Snapshot) interface{} {
+	v := snap.value(f.id, f.key)
+	if _, ok := v.(bool); ok {
 		return v
 	}
 	return f.defaultValue
@@ -53,10 +71,12 @@ func Int(key string, defaultValue int) IntFlag {
 	}
 }
 
+var _ Flag = IntFlag{}
+
 type IntFlag struct {
 	id           keyID
 	key          string
-	defaultValue int
+	defaultValue interface{}
 }
 
 // Key returns the name of the flag as passed to Int.
@@ -68,7 +88,13 @@ func (f IntFlag) Key() string {
 // given snapshot. It returns the flag's default value if snap is nil
 // or the key isn't in the configuration.
 func (f IntFlag) Get(snap *Snapshot) int {
-	if v, ok := snap.value(f.id, f.key).(int); ok {
+	return f.GetValue(snap).(int)
+}
+
+// GetValue implements Flag.GetValue.
+func (f IntFlag) GetValue(snap *Snapshot) interface{} {
+	v := snap.value(f.id, f.key)
+	if _, ok := v.(int); ok {
 		return v
 	}
 	return f.defaultValue
@@ -83,10 +109,12 @@ func String(key string, defaultValue string) StringFlag {
 	}
 }
 
+var _ Flag = StringFlag{}
+
 type StringFlag struct {
 	id           keyID
 	key          string
-	defaultValue string
+	defaultValue interface{}
 }
 
 // Key returns the name of the flag as passed to String.
@@ -98,7 +126,13 @@ func (f StringFlag) Key() string {
 // given snapshot. It returns the flag's default value if snap is nil
 // or the key isn't in the configuration.
 func (f StringFlag) Get(snap *Snapshot) string {
-	if v, ok := snap.value(f.id, f.key).(string); ok {
+	return f.GetValue(snap).(string)
+}
+
+// GetValue implements Flag.GetValue.
+func (f StringFlag) GetValue(snap *Snapshot) interface{} {
+	v := snap.value(f.id, f.key)
+	if _, ok := v.(string); ok {
 		return v
 	}
 	return f.defaultValue
@@ -113,10 +147,12 @@ func Float(key string, defaultValue float64) FloatFlag {
 	}
 }
 
+var _ Flag = FloatFlag{}
+
 type FloatFlag struct {
 	id           keyID
 	key          string
-	defaultValue float64
+	defaultValue interface{}
 }
 
 // Key returns the name of the flag as passed to Float.
@@ -128,7 +164,13 @@ func (f FloatFlag) Key() string {
 // given snapshot. It returns the flag's default value if snap is nil
 // or the key isn't in the configuration.
 func (f FloatFlag) Get(snap *Snapshot) float64 {
-	if v, ok := snap.value(f.id, f.key).(float64); ok {
+	return f.GetValue(snap).(float64)
+}
+
+// GetValue implements Flag.GetValue.
+func (f FloatFlag) GetValue(snap *Snapshot) interface{} {
+	v := snap.value(f.id, f.key)
+	if _, ok := v.(float64); ok {
 		return v
 	}
 	return f.defaultValue


### PR DESCRIPTION
This means that there's a common API for all flags
that can be used to get a flag's value as an interface.
This is technically unnecessary - a caller could use
`Snapshot.GetValue` - but using `Flag.GetValue` means
the you get to use the flag's default and the precalculated
key id that's inside the flag, which makes it more efficient.

This gives a few ns of penalty in the lowrer-cost benchmarks,
but nothing to worry about IMHO - 10ns for a call is still pretty good :)

```
name                                   old time/op    new time/op    delta
Get/one-of/get-and-make-8                 241ns ± 1%     242ns ± 3%     ~     (p=0.841 n=5+5)
Get/one-of/get-only-8                    7.40ns ± 1%    9.31ns ± 0%  +25.86%  (p=0.008 n=5+5)
Get/less-than-with-int/get-and-make-8     204ns ±11%     197ns ± 0%     ~     (p=0.690 n=5+5)
Get/less-than-with-int/get-only-8        7.38ns ± 1%    9.35ns ± 1%  +26.72%  (p=0.008 n=5+5)
Get/with-percentage/get-and-make-8        494ns ± 2%     486ns ± 0%   -1.61%  (p=0.008 n=5+5)
Get/with-percentage/get-only-8           7.36ns ± 0%    9.50ns ± 0%  +29.19%  (p=0.016 n=5+4)
Get/no-rules/get-and-make-8               117ns ± 0%     121ns ± 0%   +2.69%  (p=0.016 n=5+4)
Get/no-rules/get-only-8                  4.33ns ± 0%    6.07ns ± 0%  +40.24%  (p=0.008 n=5+5)
Get/no-user/get-and-make-8               10.6ns ± 0%    12.5ns ± 0%  +18.22%  (p=0.008 n=5+5)
Get/no-user/get-only-8                   7.37ns ± 0%    9.30ns ± 0%  +26.30%  (p=0.016 n=5+4)
NewSnapshot-8                            7.83µs ± 1%    8.96µs ±27%  +14.43%  (p=0.008 n=5+5)

name                                   old alloc/op   new alloc/op   delta
Get/one-of/get-and-make-8                  180B ± 0%      180B ± 0%     ~     (all equal)
Get/one-of/get-only-8                     0.00B          0.00B          ~     (all equal)
Get/less-than-with-int/get-and-make-8      180B ± 0%      180B ± 0%     ~     (all equal)
Get/less-than-with-int/get-only-8         0.00B          0.00B          ~     (all equal)
Get/with-percentage/get-and-make-8         252B ± 0%      252B ± 0%     ~     (all equal)
Get/with-percentage/get-only-8            0.00B          0.00B          ~     (all equal)
Get/no-rules/get-and-make-8                176B ± 0%      176B ± 0%     ~     (all equal)
Get/no-rules/get-only-8                   0.00B          0.00B          ~     (all equal)
Get/no-user/get-and-make-8                0.00B          0.00B          ~     (all equal)
Get/no-user/get-only-8                    0.00B          0.00B          ~     (all equal)
NewSnapshot-8                            5.10kB ± 0%    5.10kB ± 0%     ~     (all equal)

name                                   old allocs/op  new allocs/op  delta
Get/one-of/get-and-make-8                  2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Get/one-of/get-only-8                      0.00           0.00          ~     (all equal)
Get/less-than-with-int/get-and-make-8      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Get/less-than-with-int/get-only-8          0.00           0.00          ~     (all equal)
Get/with-percentage/get-and-make-8         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
Get/with-percentage/get-only-8             0.00           0.00          ~     (all equal)
Get/no-rules/get-and-make-8                1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Get/no-rules/get-only-8                    0.00           0.00          ~     (all equal)
Get/no-user/get-and-make-8                 0.00           0.00          ~     (all equal)
Get/no-user/get-only-8                     0.00           0.00          ~     (all equal)
NewSnapshot-8                              6.00 ± 0%      6.00 ± 0%     ~     (all equal)
```

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
