### PR TITLE
v7: add Config.DefaultUser

### DIFF
--- a/v7/snapshot.go
+++ b/v7/snapshot.go
@@ -96,8 +96,8 @@ func NewSnapshot(logger Logger, values map[string]interface{}) (*Snapshot, error
 }
 
 func newSnapshot(cfg *config, user User, logger *leveledLogger) *Snapshot {
-	if user == nil && cfg != nil {
-		return cfg.noUserSnapshot
+	if cfg != nil && (user == nil || user == cfg.defaultUser) {
+		return cfg.defaultUserSnapshot
 	}
 	return _newSnapshot(cfg, user, logger)
 }
@@ -132,6 +132,7 @@ func _newSnapshot(cfg *config, user User, logger *leveledLogger) *Snapshot {
 
 // WithUser returns a copy of s associated with the
 // given user. If snap is nil, it returns nil.
+// If user is nil, it uses Config.DefaultUser.
 func (snap *Snapshot) WithUser(user User) *Snapshot {
 	if snap == nil || snap.config == nil {
 		// Note: when there's no config, we know there are no
@@ -139,8 +140,8 @@ func (snap *Snapshot) WithUser(user User) *Snapshot {
 		// need to do anything.
 		return snap
 	}
-	if user == nil {
-		return snap.config.noUserSnapshot
+	if user == nil || user == snap.config.defaultUser {
+		return snap.config.defaultUserSnapshot
 	}
 	return newSnapshot(snap.config, user, snap.logger)
 }


### PR DESCRIPTION
Currently we optimize for the special case where there's no
user info, which considerably improves performance when
making queries when there's no current request. However
this optimization doesn't help when there are some global
attributes that are associated with all feature flag requests,
even when there's no current request context. For example,
we might want to target feature flag values based on the current
environment or machine.

This PR introduces a `DefaultUser` field to the configuration,
giving "user" information that is used whenever there's no
explicit reques, bringing the performance in this case up to
the same level as the original "no user" case.

```
name                                   old time/op    new time/op    delta
Get/one-of/get-and-make-8                 193ns ± 0%     195ns ± 1%   +1.16%  (p=0.008 n=5+5)
Get/one-of/get-only-8                    7.52ns ± 2%    7.57ns ± 3%     ~     (p=0.421 n=5+5)
Get/less-than-with-int/get-and-make-8     161ns ± 2%     185ns ±14%  +15.11%  (p=0.040 n=5+5)
Get/less-than-with-int/get-only-8        7.79ns ± 5%    8.29ns ± 0%   +6.53%  (p=0.016 n=5+4)
Get/with-percentage/get-and-make-8        445ns ± 9%     450ns ± 1%     ~     (p=1.000 n=5+5)
Get/with-percentage/get-only-8           8.38ns ± 1%    8.49ns ± 3%     ~     (p=0.151 n=5+5)
Get/no-rules/get-and-make-8               115ns ± 1%     116ns ± 5%     ~     (p=0.794 n=5+5)
Get/no-rules/get-only-8                  5.42ns ± 0%    5.49ns ± 3%     ~     (p=0.190 n=4+5)
Get/no-user/get-and-make-8               11.5ns ± 3%    11.3ns ± 0%     ~     (p=0.222 n=5+4)
Get/no-user/get-only-8                   8.80ns ±17%    8.32ns ± 1%     ~     (p=0.421 n=5+5)
NewSnapshot-8                            7.14µs ± 2%    7.35µs ± 3%     ~     (p=0.056 n=5+5)

name                                   old alloc/op   new alloc/op   delta
Get/one-of/get-and-make-8                  180B ± 0%      180B ± 0%     ~     (all equal)
Get/one-of/get-only-8                     0.00B          0.00B          ~     (all equal)
Get/less-than-with-int/get-and-make-8      180B ± 0%      180B ± 0%     ~     (all equal)
Get/less-than-with-int/get-only-8         0.00B          0.00B          ~     (all equal)
Get/with-percentage/get-and-make-8         252B ± 0%      252B ± 0%     ~     (all equal)
Get/with-percentage/get-only-8            0.00B          0.00B          ~     (all equal)
Get/no-rules/get-and-make-8                176B ± 0%      176B ± 0%     ~     (all equal)
Get/no-rules/get-only-8                   0.00B          0.00B          ~     (all equal)
Get/no-user/get-and-make-8                0.00B          0.00B          ~     (all equal)
Get/no-user/get-only-8                    0.00B          0.00B          ~     (all equal)
NewSnapshot-8                            5.10kB ± 0%    5.10kB ± 0%     ~     (all equal)

name                                   old allocs/op  new allocs/op  delta
Get/one-of/get-and-make-8                  2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Get/one-of/get-only-8                      0.00           0.00          ~     (all equal)
Get/less-than-with-int/get-and-make-8      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Get/less-than-with-int/get-only-8          0.00           0.00          ~     (all equal)
Get/with-percentage/get-and-make-8         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
Get/with-percentage/get-only-8             0.00           0.00          ~     (all equal)
Get/no-rules/get-and-make-8                1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Get/no-rules/get-only-8                    0.00           0.00          ~     (all equal)
Get/no-user/get-and-make-8                 0.00           0.00          ~     (all equal)
Get/no-user/get-only-8                     0.00           0.00          ~     (all equal)
NewSnapshot-8                              6.00 ± 0%      6.00 ± 0%     ~     (all equal)
```

The new benchmark shows a 95.75% improvement from using the new feature:

```
Get/one-of/get-and-make-8                     195ns ± 1%
Get/one-of-with-default-user/get-and-make-8  12.2ns ± 0%
```

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
