### PR TITLE
v7/configcattest: add variation IDs

### DIFF
--- a/v7/configcattest/flag.go
+++ b/v7/configcattest/flag.go
@@ -38,17 +38,18 @@ type Rule struct {
 	Value interface{}
 }
 
-func (f *Flag) entry() (*wireconfig.Entry, error) {
+func (f *Flag) entry(key string) (*wireconfig.Entry, error) {
 	ft := typeOf(f.Default)
 	if ft == invalidEntry {
 		return nil, fmt.Errorf("invalid type %T for default value %#v", f.Default, f.Default)
 	}
 	e := &wireconfig.Entry{
+		VariationID:  "v_" + key,
 		Type:         ft,
 		Value:        f.Default,
 		RolloutRules: make([]*wireconfig.RolloutRule, 0, len(f.Rules)),
 	}
-	for _, rule := range f.Rules {
+	for i, rule := range f.Rules {
 		if rule.Comparator.String() == "" {
 			return nil, fmt.Errorf("invalid comparator value %d", rule.Comparator)
 		}
@@ -66,6 +67,7 @@ func (f *Flag) entry() (*wireconfig.Entry, error) {
 			ComparisonAttribute: rule.ComparisonAttribute,
 			Comparator:          wireconfig.Operator(rule.Comparator),
 			ComparisonValue:     rule.ComparisonValue,
+			VariationID:         fmt.Sprintf("v%d_%s", i, key),
 		})
 	}
 	return e, nil

--- a/v7/configcattest/handler.go
+++ b/v7/configcattest/handler.go
@@ -64,7 +64,7 @@ func makeContent(flags map[string]*Flag) ([]byte, error) {
 		Entries: make(map[string]*wireconfig.Entry, len(flags)),
 	}
 	for name, flag := range flags {
-		e, err := flag.entry()
+		e, err := flag.entry(name)
 		if err != nil {
 			return nil, fmt.Errorf("invalid flag %q: %v", name, err)
 		}


### PR DESCRIPTION
The v6 feature flag logic ignores rules when they don't
have a variation ID, so include an arbitrary variation ID
so that it the configcattest server works for tests against
that client too.
