### PR TITLE
fix: v7: fix panic when key isn't found

### DIFF
--- a/v7/snapshot.go
+++ b/v7/snapshot.go
@@ -157,8 +157,20 @@ func (snap *Snapshot) value(id keyID, key string) interface{} {
 	}
 	valID := snap.precalc[id]
 	if valID > 0 {
+		// We've got a precalculated value for the key.
 		return snap.valueForID(valID)
 	}
+	if valID == 0 {
+		// The key isn't found in this configuration.
+		if !snap.logger.enabled(LogLevelError) {
+			return nil
+		}
+		// Use the default implementation which will do the
+		// appropriate logging for us.
+		val, _ := snap.valueAndVariationID(id, key)
+		return val
+	}
+	// Look up the key in the cache.
 	cacheIndex := int(-valID - 1)
 	snap.initCache()
 	if valID := atomic.LoadInt32(&snap.cache[cacheIndex]); valID > 0 {


### PR DESCRIPTION
This PR fixes an oversight that when there are empty slots
in the configuration's precalculated value slice, the
logic didn't check for that and instead tried to use the zero
value as a bad cache index, leading to a panic.

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
