### PR TITLE
Add flag overrides and GetAllValues() function

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: v7
     strategy:
       matrix:
-        go: [1.14.x, 1.15.x, 1.16.x]
+        go: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x]
     
     steps:
     - uses: actions/checkout@v2

--- a/resources/local-simple.json
+++ b/resources/local-simple.json
@@ -1,0 +1,9 @@
+{
+  "flags": {
+    "disabledFeature": false,
+    "enabledFeature": true,
+    "intSetting": 5,
+    "doubleSetting": 3.14,
+    "stringSetting": "test"
+  }
+}

--- a/resources/local.json
+++ b/resources/local.json
@@ -1,0 +1,19 @@
+{
+  "f": {
+    "disabledFeature": {
+      "v": false
+    },
+    "enabledFeature": {
+      "v": true
+    },
+    "intSetting": {
+      "v": 5
+    },
+    "doubleSetting": {
+      "v": 3.14
+    },
+    "stringSetting": {
+      "v": "test"
+    }
+  }
+}

--- a/samples/console/main.go
+++ b/samples/console/main.go
@@ -2,18 +2,23 @@ package main
 
 import (
 	"fmt"
-	"github.com/configcat/go-sdk/v6"
+	"github.com/configcat/go-sdk/v7"
 )
 
 func main() {
-	client := configcat.NewCustomClient("PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ",
-		configcat.ClientConfig{Logger: configcat.DefaultLogger(configcat.LogLevelInfo)})
+	client := configcat.NewCustomClient(configcat.Config{
+		SDKKey: "PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ",
+		Logger: configcat.DefaultLogger(configcat.LogLevelInfo),
+	})
 
 	// create a user object to identify your user (optional)
-	user := configcat.NewUserWithAdditionalAttributes("##SOME-USER-IDENTIFICATION##", "configcat@example.com", "", nil)
+	user := &configcat.UserData{
+		Identifier: "##SOME-USER-IDENTIFICATION##",
+		Email:      "configcat@example.com",
+	}
 
 	// get individual config values identified by a key and a user object
-	value := client.GetValueForUser("isPOCFeatureEnabled", false, user)
+	value := client.GetBoolValue("isPOCFeatureEnabled", false, user)
 
 	fmt.Println("isPOCFeatureEnabled: ", value)
 }

--- a/v7/config_fetcher.go
+++ b/v7/config_fetcher.go
@@ -30,7 +30,7 @@ type configFetcher struct {
 	changeNotify      func()
 	defaultUser       User
 	pollingIdentifier string
-	overrides         *FlagOverrides
+	overrides         FlagOverrides
 
 	ctx       context.Context
 	ctxCancel func()

--- a/v7/config_fetcher.go
+++ b/v7/config_fetcher.go
@@ -194,6 +194,14 @@ func (f *configFetcher) fetcher(prevConfig *config, logError bool) {
 }
 
 func (f *configFetcher) fetchConfig(ctx context.Context, baseURL string, prevConfig *config) (_ *config, _newURL string, _err error) {
+	if f.overrides != nil && f.overrides.Behavior == LocalOnly {
+		// TODO could potentially refresh f.overrides if it's come from a file.
+		cfg, err := parseConfig(nil, "", time.Now(), f.logger, f.defaultUser, f.overrides)
+		if err != nil {
+			return nil, "", err
+		}
+		return cfg, "", nil
+	}
 	cfg, newBaseURL, err := f.fetchHTTP(ctx, baseURL, prevConfig)
 	if err == nil {
 		return cfg, newBaseURL, nil

--- a/v7/config_fetcher.go
+++ b/v7/config_fetcher.go
@@ -30,7 +30,7 @@ type configFetcher struct {
 	changeNotify      func()
 	defaultUser       User
 	pollingIdentifier string
-	overrides         FlagOverrides
+	overrides         *FlagOverrides
 
 	ctx       context.Context
 	ctxCancel func()

--- a/v7/config_parser.go
+++ b/v7/config_parser.go
@@ -50,12 +50,12 @@ type config struct {
 // than the index into the config.values or Snapshot.values slice.
 type valueID = int32
 
-func parseConfig(jsonBody []byte, etag string, fetchTime time.Time, logger *leveledLogger, defaultUser User, overrides FlagOverrides) (*config, error) {
+func parseConfig(jsonBody []byte, etag string, fetchTime time.Time, logger *leveledLogger, defaultUser User, overrides *FlagOverrides) (*config, error) {
 	var root wireconfig.RootNode
 	if err := json.Unmarshal(jsonBody, &root); err != nil {
 		return nil, err
 	}
-	if overrides.entries != nil {
+	if overrides != nil {
 		mergeEntriesWithOverrides(root.Entries, overrides.entries, overrides.Behaviour)
 	}
 	conf := &config{

--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -1,4 +1,4 @@
-// ConfigCat SDK for Go (https://configcat.com)
+// Package configcat contains the Go SDK of ConfigCat (https://configcat.com)
 package configcat
 
 import (
@@ -82,6 +82,9 @@ type Config struct {
 	// more efficient to use DefaultUser=u than to call flagger.Snapshot(u)
 	// on every feature flag evaluation.
 	DefaultUser User
+
+	// FlagOverrides holds the feature flag and setting overrides.
+	FlagOverrides *FlagOverrides
 }
 
 // ConfigCache is a cache API used to make custom cache implementations.
@@ -107,6 +110,7 @@ type Client struct {
 	logger         *leveledLogger
 	cfg            Config
 	fetcher        *configFetcher
+	overrides      *FlagOverrides
 	needGetCheck   bool
 	firstFetchWait sync.Once
 	defaultUser    User
@@ -151,12 +155,20 @@ func NewCustomClient(cfg Config) *Client {
 		cfg.PollInterval = DefaultPollInterval
 	}
 	logger := newLeveledLogger(cfg.Logger)
+	var fetcher *configFetcher
+	if cfg.FlagOverrides == nil || cfg.FlagOverrides.Behaviour != LocalOnly {
+		fetcher = newConfigFetcher(cfg, logger, cfg.DefaultUser)
+	}
+	if cfg.FlagOverrides != nil {
+		cfg.FlagOverrides.preLoad(logger)
+	}
 	return &Client{
 		cfg:          cfg,
 		logger:       logger,
-		fetcher:      newConfigFetcher(cfg, logger, cfg.DefaultUser),
+		fetcher:      fetcher,
 		needGetCheck: cfg.PollingMode == Lazy || cfg.PollingMode == AutoPoll && !cfg.NoWaitForRefresh,
 		defaultUser:  cfg.DefaultUser,
+		overrides:    cfg.FlagOverrides,
 	}
 }
 
@@ -167,19 +179,27 @@ func (client *Client) Refresh(ctx context.Context) error {
 	// Note: add a tiny bit to the current time so that we refresh
 	// even if the current time hasn't changed since the last
 	// time we refreshed.
-	return client.fetcher.refreshIfOlder(ctx, time.Now().Add(1), true)
+	if client.fetcher != nil {
+		return client.fetcher.refreshIfOlder(ctx, time.Now().Add(1), true)
+	}
+	return nil
 }
 
 // RefreshIfOlder is like Refresh but refreshes the configuration only
 // if the most recently fetched configuration is older than the given
 // age.
 func (client *Client) RefreshIfOlder(ctx context.Context, age time.Duration) error {
-	return client.fetcher.refreshIfOlder(ctx, time.Now().Add(-age), true)
+	if client.fetcher != nil {
+		return client.fetcher.refreshIfOlder(ctx, time.Now().Add(-age), true)
+	}
+	return nil
 }
 
 // Close shuts down the client. After closing, it shouldn't be used.
 func (client *Client) Close() {
-	client.fetcher.close()
+	if client.fetcher != nil {
+		client.fetcher.close()
+	}
 }
 
 // GetBoolValue returns the value of a boolean-typed feature flag, or defaultValue if no
@@ -236,10 +256,27 @@ func (client *Client) GetAllKeys() []string {
 	return client.Snapshot(nil).GetAllKeys()
 }
 
-// Snapshot returns an immuatable snapshot of the most recent feature
+// GetAllValues returns all keys and values in a key-value map.
+func (client *Client) GetAllValues(user User) map[string]interface{} {
+	return client.Snapshot(user).GetAllValues()
+}
+
+// Snapshot returns an immutable snapshot of the most recent feature
 // flags retrieved by the client, associated with the given user, or
 // Config.DefaultUser if user is nil.
 func (client *Client) Snapshot(user User) *Snapshot {
+	if client.overrides != nil && client.overrides.Behaviour == LocalOnly {
+		result := make(map[string]interface{}, len(client.overrides.entries))
+		for key, entry := range client.overrides.entries {
+			result[key] = entry.Value
+		}
+		snap, err := NewSnapshot(client.logger, result)
+		if err != nil {
+			client.logger.Errorf("could not create local only snapshot: %v", err)
+			return nil
+		}
+		return snap
+	}
 	if client.needGetCheck {
 		switch client.cfg.PollingMode {
 		case Lazy:

--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -159,7 +159,7 @@ func NewCustomClient(cfg Config) *Client {
 		cfg.FlagOverrides.preLoad(logger)
 	}
 	var fetcher *configFetcher
-	if (!cfg.FlagOverrides.isValid()) || cfg.FlagOverrides.Behaviour != LocalOnly {
+	if cfg.FlagOverrides.entries == nil || cfg.FlagOverrides.Behaviour != LocalOnly {
 		fetcher = newConfigFetcher(cfg, logger, cfg.DefaultUser)
 	}
 	return &Client{

--- a/v7/configcat_client_test.go
+++ b/v7/configcat_client_test.go
@@ -178,7 +178,7 @@ func TestClient_Get_WithEmptySDKKey(t *testing.T) {
 	c := qt.New(t)
 	client := NewClient("")
 	err := client.Refresh(context.Background())
-	c.Assert(err, qt.ErrorMatches, `config fetch failed: empty SDK key in configcat configuration!`)
+	c.Assert(err, qt.ErrorMatches, `config fetch failed: empty SDK key in configcat configuration`)
 }
 
 func TestClient_Get_WithEmptyKey(t *testing.T) {
@@ -200,6 +200,19 @@ func TestClient_Keys(t *testing.T) {
 	client.Refresh(context.Background())
 
 	keys := client.GetAllKeys()
+	c.Assert(keys, qt.HasLen, 16)
+}
+
+func TestClient_AllValues(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+	client := NewCustomClient(srv.config())
+	client.Refresh(context.Background())
+
+	keys := client.GetAllValues(nil)
 	c.Assert(keys, qt.HasLen, 16)
 }
 
@@ -296,7 +309,7 @@ func TestClient_GetWithDifferentURLAndNoRedirect(t *testing.T) {
 			Redirect: &redirect,
 		},
 		Entries: map[string]*wireconfig.Entry{
-			"key": &wireconfig.Entry{
+			"key": {
 				Value: "value1",
 			},
 		},
@@ -324,7 +337,7 @@ func TestClient_GetWithRedirectToSameURL(t *testing.T) {
 			Redirect: &redirect,
 		},
 		Entries: map[string]*wireconfig.Entry{
-			"key": &wireconfig.Entry{
+			"key": {
 				Value: "value1",
 			},
 		},
@@ -400,7 +413,7 @@ func TestClient_GetWithStandardURLAndNoRedirect(t *testing.T) {
 			Redirect: &redirect,
 		},
 		Entries: map[string]*wireconfig.Entry{
-			"key": &wireconfig.Entry{
+			"key": {
 				Value: "value1",
 			},
 		},
@@ -486,7 +499,7 @@ func TestClient_DefaultUser(t *testing.T) {
 
 	srv.setResponseJSON(&wireconfig.RootNode{
 		Entries: map[string]*wireconfig.Entry{
-			"foo": &wireconfig.Entry{
+			"foo": {
 				Value: "default",
 				Type:  wireconfig.StringEntry,
 				RolloutRules: []*wireconfig.RolloutRule{{
@@ -550,7 +563,7 @@ func getTestClients(t *testing.T) (*configServer, *Client) {
 func rootNodeWithKeyValue(key string, value interface{}, typ wireconfig.EntryType) *wireconfig.RootNode {
 	return &wireconfig.RootNode{
 		Entries: map[string]*wireconfig.Entry{
-			key: &wireconfig.Entry{
+			key: {
 				Value: value,
 				Type:  typ,
 			},

--- a/v7/flag.go
+++ b/v7/flag.go
@@ -170,8 +170,11 @@ func (f FloatFlag) Get(snap *Snapshot) float64 {
 // GetValue implements Flag.GetValue.
 func (f FloatFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
-	if _, ok := v.(float64); ok {
-		return v
+	switch result := v.(type) {
+	case int:
+		return float64(result)
+	case float64:
+		return result
 	}
 	return f.defaultValue
 }

--- a/v7/flag.go
+++ b/v7/flag.go
@@ -94,8 +94,11 @@ func (f IntFlag) Get(snap *Snapshot) int {
 // GetValue implements Flag.GetValue.
 func (f IntFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
-	if _, ok := v.(int); ok {
+	switch v1 := v.(type) {
+	case int:
 		return v
+	case float64:
+		return int(v1)
 	}
 	return f.defaultValue
 }
@@ -170,11 +173,8 @@ func (f FloatFlag) Get(snap *Snapshot) float64 {
 // GetValue implements Flag.GetValue.
 func (f FloatFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
-	switch result := v.(type) {
-	case int:
-		return float64(result)
-	case float64:
-		return result
+	if _, ok := v.(float64); ok {
+		return v
 	}
 	return f.defaultValue
 }

--- a/v7/flag_overrides.go
+++ b/v7/flag_overrides.go
@@ -43,7 +43,7 @@ type FlagOverrides struct {
 	Values map[string]interface{}
 
 	// FilePath is the path to a JSON file that contains the overrides.
-	// TODO link to docs on the format of this.
+	// The supported JSON file formats are documented here: https://configcat.com/docs/sdk-reference/go/#json-file-structure
 	FilePath string
 
 	// entries is populated by loadEntries from the above fields.

--- a/v7/flag_overrides.go
+++ b/v7/flag_overrides.go
@@ -1,0 +1,128 @@
+package configcat
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
+	"io"
+	"io/ioutil"
+)
+
+// OverrideBehaviour describes how the overrides should behave.
+type OverrideBehaviour int
+
+const (
+	// LocalOnly means that when evaluating values, the SDK will not use feature flags and settings from the
+	// ConfigCat CDN, but it will use all feature flags and settings that are loaded from local-override sources.
+	LocalOnly = 0
+
+	// LocalOverRemote means that when evaluating values, the SDK will use all feature flags and settings that are
+	// downloaded from the ConfigCat CDN, plus all feature flags and settings that are loaded from
+	// local-override sources. If a feature flag or a setting is defined both in the fetched and the local-override
+	// source then the local-override version will take precedence.
+	LocalOverRemote = 1
+
+	// RemoteOverLocal means when evaluating values, the SDK will use all feature flags and settings that are
+	// downloaded from the ConfigCat CDN, plus all feature flags and settings that are loaded from local-override
+	// sources. If a feature flag or a setting is defined both in the fetched and the local-override source then the
+	// fetched version will take precedence.
+	RemoteOverLocal = 2
+)
+
+// FlagOverrides describes feature flag and setting overrides. With flag overrides you can overwrite the
+// feature flags downloaded from the ConfigCat CDN with local values.
+//
+// With Values, you can set up the SDK to load your feature flag overrides from a map.
+//
+// With FilePath, you can set up the SDK to load your feature flag overrides from a JSON file.
+type FlagOverrides struct {
+	// Behaviour describes how the overrides should behave. Default is LocalOnly.
+	Behaviour OverrideBehaviour
+
+	// Values is a map that contains the overrides.
+	Values map[string]interface{}
+
+	// FilePath is the path to a JSON file that contains the overrides.
+	FilePath string
+
+	entries map[string]*wireconfig.Entry
+}
+
+func (f *FlagOverrides) preLoad(logger *leveledLogger) {
+	f.entries = f.loadEntries(logger)
+	f.fixEntries()
+}
+
+func (f *FlagOverrides) loadEntries(logger *leveledLogger) map[string]*wireconfig.Entry {
+	if f.Behaviour != LocalOnly && f.Behaviour != LocalOverRemote && f.Behaviour != RemoteOverLocal {
+		logger.Errorf("flag overrides configuration is invalid. 'Behavior' value: %v.", f.Behaviour)
+		return map[string]*wireconfig.Entry{}
+	}
+	if f.Values == nil && f.FilePath == "" {
+		logger.Errorf("flag overrides configuration is invalid. 'Values' or 'FilePath' must be set.")
+		return map[string]*wireconfig.Entry{}
+	}
+	if f.Values != nil {
+		entries := make(map[string]*wireconfig.Entry, len(f.Values))
+		for key, value := range f.Values {
+			entries[key] = &wireconfig.Entry{
+				Value:       value,
+				VariationID: "",
+			}
+		}
+		return entries
+	}
+	return f.loadEntriesFromFile(logger)
+}
+
+func (f *FlagOverrides) loadEntriesFromFile(logger *leveledLogger) map[string]*wireconfig.Entry {
+	data, err := ioutil.ReadFile(f.FilePath)
+	if err != nil {
+		logger.Errorf("unable to read local JSON file: %v", err)
+		return map[string]*wireconfig.Entry{}
+	}
+	var simplified wireconfig.SimplifiedConfig
+	reader := bytes.NewReader(data)
+	decoder := json.NewDecoder(reader)
+	decoder.UseNumber()
+	if err := decoder.Decode(&simplified); err == nil && simplified.Flags != nil {
+		entries := make(map[string]*wireconfig.Entry, len(simplified.Flags))
+		for key, value := range simplified.Flags {
+			entries[key] = &wireconfig.Entry{
+				Value:       value,
+				VariationID: "",
+			}
+		}
+		return entries
+	}
+	var root wireconfig.RootNode
+	if _, err = reader.Seek(0, io.SeekStart); err != nil {
+		logger.Errorf("error during reading local JSON file: %v", err)
+		return map[string]*wireconfig.Entry{}
+	}
+	if err := decoder.Decode(&root); err != nil {
+		logger.Errorf("error during reading local JSON file: %v", err)
+		return map[string]*wireconfig.Entry{}
+	}
+	return root.Entries
+}
+
+func (f *FlagOverrides) fixEntries() {
+	for _, entry := range f.entries {
+		if b, ok := entry.Value.(bool); ok {
+			entry.Value = b
+			entry.Type = wireconfig.BoolEntry
+		} else if s, ok := entry.Value.(string); ok {
+			entry.Value = s
+			entry.Type = wireconfig.StringEntry
+		} else if n, ok := entry.Value.(json.Number); ok {
+			if i, err := n.Int64(); err == nil {
+				entry.Value = int(i)
+				entry.Type = wireconfig.IntEntry
+			} else if fl, err := n.Float64(); err == nil {
+				entry.Value = fl
+				entry.Type = wireconfig.FloatEntry
+			}
+		}
+	}
+}

--- a/v7/flag_overrides.go
+++ b/v7/flag_overrides.go
@@ -48,6 +48,10 @@ type FlagOverrides struct {
 	entries map[string]*wireconfig.Entry
 }
 
+func (f *FlagOverrides) isValid() bool {
+	return f.Values != nil || f.FilePath != ""
+}
+
 func (f *FlagOverrides) preLoad(logger *leveledLogger) {
 	f.entries = f.loadEntries(logger)
 	f.fixEntries()

--- a/v7/flag_overrides_test.go
+++ b/v7/flag_overrides_test.go
@@ -10,7 +10,7 @@ import (
 func TestFlagOverrides_File_Simple(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
-		FlagOverrides: FlagOverrides{
+		FlagOverrides: &FlagOverrides{
 			FilePath: "../resources/local-simple.json",
 		},
 	}
@@ -27,7 +27,7 @@ func TestFlagOverrides_File_Simple(t *testing.T) {
 func TestFlagOverrides_File_Complex(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
-		FlagOverrides: FlagOverrides{
+		FlagOverrides: &FlagOverrides{
 			FilePath: "../resources/local.json",
 		},
 	}
@@ -41,10 +41,23 @@ func TestFlagOverrides_File_Complex(t *testing.T) {
 	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "test")
 }
 
+func TestFlagOverrides_Int_Float(t *testing.T) {
+	c := qt.New(t)
+	cfg := Config{
+		FlagOverrides: &FlagOverrides{
+			FilePath: "../resources/local-simple.json",
+		},
+	}
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	c.Assert(client.GetFloatValue("intSetting", 0, nil), qt.Equals, 5.0)
+}
+
 func TestFlagOverrides_Values_LocalOnly(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
-		FlagOverrides: FlagOverrides{
+		FlagOverrides: &FlagOverrides{
 			Values: map[string]interface{}{
 				"enabledFeature":  true,
 				"disabledFeature": false,
@@ -67,7 +80,7 @@ func TestFlagOverrides_Values_LocalOnly(t *testing.T) {
 func TestFlagOverrides_Values_Ignored_On_Wrong_Behaviour(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
-		FlagOverrides: FlagOverrides{
+		FlagOverrides: &FlagOverrides{
 			Values: map[string]interface{}{
 				"enabledFeature":  true,
 				"disabledFeature": false,
@@ -94,7 +107,7 @@ func TestFlagOverrides_Values_LocalOverRemote(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = FlagOverrides{
+	cfg.FlagOverrides = &FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey":     true,
 			"nonexisting": true,
@@ -117,7 +130,7 @@ func TestFlagOverrides_Values_RemoteOverLocal(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = FlagOverrides{
+	cfg.FlagOverrides = &FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey":     true,
 			"nonexisting": true,
@@ -140,7 +153,7 @@ func TestFlagOverrides_Values_Remote_Invalid(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = FlagOverrides{
+	cfg.FlagOverrides = &FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey": true,
 			"invalid": BoolFlag{},
@@ -163,7 +176,7 @@ func TestFlagOverrides_Values_Local_Invalid(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = FlagOverrides{
+	cfg.FlagOverrides = &FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey": true,
 			"invalid": BoolFlag{},

--- a/v7/flag_overrides_test.go
+++ b/v7/flag_overrides_test.go
@@ -2,9 +2,10 @@ package configcat
 
 import (
 	"context"
+	"testing"
+
 	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 	qt "github.com/frankban/quicktest"
-	"testing"
 )
 
 func TestFlagOverrides_File_Simple(t *testing.T) {
@@ -77,7 +78,7 @@ func TestFlagOverrides_Values_LocalOnly(t *testing.T) {
 	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "test")
 }
 
-func TestFlagOverrides_Values_Ignored_On_Wrong_Behaviour(t *testing.T) {
+func TestFlagOverrides_Values_Ignored_On_Wrong_Behavior(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
 		FlagOverrides: &FlagOverrides{
@@ -88,7 +89,7 @@ func TestFlagOverrides_Values_Ignored_On_Wrong_Behaviour(t *testing.T) {
 				"doubleSetting":   3.14,
 				"stringSetting":   "test",
 			},
-			Behaviour: 5,
+			Behavior: 5,
 		},
 	}
 	client := NewCustomClient(cfg)
@@ -112,7 +113,7 @@ func TestFlagOverrides_Values_LocalOverRemote(t *testing.T) {
 			"fakeKey":     true,
 			"nonexisting": true,
 		},
-		Behaviour: LocalOverRemote,
+		Behavior: LocalOverRemote,
 	}
 
 	client := NewCustomClient(cfg)
@@ -135,7 +136,7 @@ func TestFlagOverrides_Values_RemoteOverLocal(t *testing.T) {
 			"fakeKey":     true,
 			"nonexisting": true,
 		},
-		Behaviour: RemoteOverLocal,
+		Behavior: RemoteOverLocal,
 	}
 
 	client := NewCustomClient(cfg)
@@ -158,7 +159,7 @@ func TestFlagOverrides_Values_Remote_Invalid(t *testing.T) {
 			"fakeKey": true,
 			"invalid": BoolFlag{},
 		},
-		Behaviour: RemoteOverLocal,
+		Behavior: RemoteOverLocal,
 	}
 
 	client := NewCustomClient(cfg)
@@ -181,7 +182,7 @@ func TestFlagOverrides_Values_Local_Invalid(t *testing.T) {
 			"fakeKey": true,
 			"invalid": BoolFlag{},
 		},
-		Behaviour: LocalOnly,
+		Behavior: LocalOnly,
 	}
 
 	client := NewCustomClient(cfg)
@@ -189,6 +190,6 @@ func TestFlagOverrides_Values_Local_Invalid(t *testing.T) {
 	err := client.Refresh(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
-	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsFalse)
+	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsTrue)
 	c.Assert(client.GetBoolValue("invalid", false, nil), qt.IsFalse)
 }

--- a/v7/flag_overrides_test.go
+++ b/v7/flag_overrides_test.go
@@ -10,7 +10,7 @@ import (
 func TestFlagOverrides_File_Simple(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
-		FlagOverrides: &FlagOverrides{
+		FlagOverrides: FlagOverrides{
 			FilePath: "../resources/local-simple.json",
 		},
 	}
@@ -27,7 +27,7 @@ func TestFlagOverrides_File_Simple(t *testing.T) {
 func TestFlagOverrides_File_Complex(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
-		FlagOverrides: &FlagOverrides{
+		FlagOverrides: FlagOverrides{
 			FilePath: "../resources/local.json",
 		},
 	}
@@ -44,7 +44,7 @@ func TestFlagOverrides_File_Complex(t *testing.T) {
 func TestFlagOverrides_Values_LocalOnly(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
-		FlagOverrides: &FlagOverrides{
+		FlagOverrides: FlagOverrides{
 			Values: map[string]interface{}{
 				"enabledFeature":  true,
 				"disabledFeature": false,
@@ -70,7 +70,7 @@ func TestFlagOverrides_Values_LocalOverRemote(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = &FlagOverrides{
+	cfg.FlagOverrides = FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey":     true,
 			"nonexisting": true,
@@ -93,7 +93,7 @@ func TestFlagOverrides_Values_RemoteOverLocal(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = &FlagOverrides{
+	cfg.FlagOverrides = FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey":     true,
 			"nonexisting": true,
@@ -116,7 +116,7 @@ func TestFlagOverrides_Values_Remote_Invalid(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = &FlagOverrides{
+	cfg.FlagOverrides = FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey": true,
 			"invalid": BoolFlag{},
@@ -139,7 +139,7 @@ func TestFlagOverrides_Values_Local_Invalid(t *testing.T) {
 	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
 	cfg := srv.config()
 
-	cfg.FlagOverrides = &FlagOverrides{
+	cfg.FlagOverrides = FlagOverrides{
 		Values: map[string]interface{}{
 			"fakeKey": true,
 			"invalid": BoolFlag{},

--- a/v7/flag_overrides_test.go
+++ b/v7/flag_overrides_test.go
@@ -64,6 +64,30 @@ func TestFlagOverrides_Values_LocalOnly(t *testing.T) {
 	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "test")
 }
 
+func TestFlagOverrides_Values_Ignored_On_Wrong_Behaviour(t *testing.T) {
+	c := qt.New(t)
+	cfg := Config{
+		FlagOverrides: FlagOverrides{
+			Values: map[string]interface{}{
+				"enabledFeature":  true,
+				"disabledFeature": false,
+				"intSetting":      5,
+				"doubleSetting":   3.14,
+				"stringSetting":   "test",
+			},
+			Behaviour: 5,
+		},
+	}
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	c.Assert(client.GetBoolValue("enabledFeature", false, nil), qt.IsFalse)
+	c.Assert(client.GetBoolValue("disabledFeature", false, nil), qt.IsFalse)
+	c.Assert(client.GetIntValue("intSetting", 0, nil), qt.Equals, 0)
+	c.Assert(client.GetFloatValue("doubleSetting", 0.0, nil), qt.Equals, 0.0)
+	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "")
+}
+
 func TestFlagOverrides_Values_LocalOverRemote(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)

--- a/v7/flag_overrides_test.go
+++ b/v7/flag_overrides_test.go
@@ -1,0 +1,157 @@
+package configcat
+
+import (
+	"context"
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
+	qt "github.com/frankban/quicktest"
+	"testing"
+)
+
+func TestFlagOverrides_File_Simple(t *testing.T) {
+	c := qt.New(t)
+	cfg := Config{
+		FlagOverrides: &FlagOverrides{
+			FilePath: "../resources/local-simple.json",
+		},
+	}
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	c.Assert(client.GetBoolValue("enabledFeature", false, nil), qt.IsTrue)
+	c.Assert(client.GetBoolValue("disabledFeature", false, nil), qt.IsFalse)
+	c.Assert(client.GetIntValue("intSetting", 0, nil), qt.Equals, 5)
+	c.Assert(client.GetFloatValue("doubleSetting", 0.0, nil), qt.Equals, 3.14)
+	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "test")
+}
+
+func TestFlagOverrides_File_Complex(t *testing.T) {
+	c := qt.New(t)
+	cfg := Config{
+		FlagOverrides: &FlagOverrides{
+			FilePath: "../resources/local.json",
+		},
+	}
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	c.Assert(client.GetBoolValue("enabledFeature", false, nil), qt.IsTrue)
+	c.Assert(client.GetBoolValue("disabledFeature", false, nil), qt.IsFalse)
+	c.Assert(client.GetIntValue("intSetting", 0, nil), qt.Equals, 5)
+	c.Assert(client.GetFloatValue("doubleSetting", 0.0, nil), qt.Equals, 3.14)
+	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "test")
+}
+
+func TestFlagOverrides_Values_LocalOnly(t *testing.T) {
+	c := qt.New(t)
+	cfg := Config{
+		FlagOverrides: &FlagOverrides{
+			Values: map[string]interface{}{
+				"enabledFeature":  true,
+				"disabledFeature": false,
+				"intSetting":      5,
+				"doubleSetting":   3.14,
+				"stringSetting":   "test",
+			},
+		},
+	}
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	c.Assert(client.GetBoolValue("enabledFeature", false, nil), qt.IsTrue)
+	c.Assert(client.GetBoolValue("disabledFeature", false, nil), qt.IsFalse)
+	c.Assert(client.GetIntValue("intSetting", 0, nil), qt.Equals, 5)
+	c.Assert(client.GetFloatValue("doubleSetting", 0.0, nil), qt.Equals, 3.14)
+	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "test")
+}
+
+func TestFlagOverrides_Values_LocalOverRemote(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
+	cfg := srv.config()
+
+	cfg.FlagOverrides = &FlagOverrides{
+		Values: map[string]interface{}{
+			"fakeKey":     true,
+			"nonexisting": true,
+		},
+		Behaviour: LocalOverRemote,
+	}
+
+	client := NewCustomClient(cfg)
+	defer client.Close()
+	err := client.Refresh(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsTrue)
+	c.Assert(client.GetBoolValue("nonexisting", false, nil), qt.IsTrue)
+}
+
+func TestFlagOverrides_Values_RemoteOverLocal(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
+	cfg := srv.config()
+
+	cfg.FlagOverrides = &FlagOverrides{
+		Values: map[string]interface{}{
+			"fakeKey":     true,
+			"nonexisting": true,
+		},
+		Behaviour: RemoteOverLocal,
+	}
+
+	client := NewCustomClient(cfg)
+	defer client.Close()
+	err := client.Refresh(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsFalse)
+	c.Assert(client.GetBoolValue("nonexisting", false, nil), qt.IsTrue)
+}
+
+func TestFlagOverrides_Values_Remote_Invalid(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
+	cfg := srv.config()
+
+	cfg.FlagOverrides = &FlagOverrides{
+		Values: map[string]interface{}{
+			"fakeKey": true,
+			"invalid": BoolFlag{},
+		},
+		Behaviour: RemoteOverLocal,
+	}
+
+	client := NewCustomClient(cfg)
+	defer client.Close()
+	err := client.Refresh(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsFalse)
+	c.Assert(client.GetBoolValue("invalid", false, nil), qt.IsFalse)
+}
+
+func TestFlagOverrides_Values_Local_Invalid(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponseJSON(rootNodeWithKeyValue("fakeKey", false, wireconfig.BoolEntry))
+	cfg := srv.config()
+
+	cfg.FlagOverrides = &FlagOverrides{
+		Values: map[string]interface{}{
+			"fakeKey": true,
+			"invalid": BoolFlag{},
+		},
+		Behaviour: LocalOnly,
+	}
+
+	client := NewCustomClient(cfg)
+	defer client.Close()
+	err := client.Refresh(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsFalse)
+	c.Assert(client.GetBoolValue("invalid", false, nil), qt.IsFalse)
+}

--- a/v7/internal/wireconfig/wireconfig.go
+++ b/v7/internal/wireconfig/wireconfig.go
@@ -41,6 +41,10 @@ type Preferences struct {
 	Redirect *RedirectionKind `json:"r"` // NoRedirect, ShouldRedirect or ForceRedirect
 }
 
+type SimplifiedConfig struct {
+	Flags map[string]interface{} `json:"flags"`
+}
+
 type RedirectionKind int
 
 const (

--- a/v7/policy_test.go
+++ b/v7/policy_test.go
@@ -11,7 +11,7 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-// TestFetchFailWithCacheFallback tests that cache fallback behaviour
+// TestFetchFailWithCacheFallback tests that cache fallback behavior
 // works as expected.
 func TestFetchFailWithCacheFallback(t *testing.T) {
 	c := qt.New(t)

--- a/v7/snapshot.go
+++ b/v7/snapshot.go
@@ -279,3 +279,17 @@ func (snap *Snapshot) GetAllKeys() []string {
 	}
 	return snap.allKeys
 }
+
+// GetAllValues returns all keys and values in a key-value map.
+func (snap *Snapshot) GetAllValues() map[string]interface{} {
+	if snap == nil || snap.config == nil {
+		return nil
+	}
+	keys := snap.config.keys()
+	values := make(map[string]interface{}, len(keys))
+	for _, key := range keys {
+		id := idForKey(key, false)
+		values[key] = snap.value(id, key)
+	}
+	return values
+}

--- a/v7/version.go
+++ b/v7/version.go
@@ -1,4 +1,4 @@
 package configcat
 
 // TODO read this from runtime.BuildInfo?
-const version = "7.4.1"
+const version = "7.5.0"


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR applies the following:
- A `GetAllValues()` function that evaluates all flags & settings in a `map[string]interface{}`.
- New `FlagOverrides` configuration option to support the reading of flags & settings from a local file or from a `map[string]interface{}`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
