### PR TITLE
suggested amendments to overrides logic

### DIFF
--- a/v7/config_fetcher.go
+++ b/v7/config_fetcher.go
@@ -194,6 +194,14 @@ func (f *configFetcher) fetcher(prevConfig *config, logError bool) {
 }
 
 func (f *configFetcher) fetchConfig(ctx context.Context, baseURL string, prevConfig *config) (_ *config, _newURL string, _err error) {
+	if f.overrides != nil && f.overrides.Behavior == LocalOnly {
+		// TODO could potentially refresh f.overrides if it's come from a file.
+		cfg, err := parseConfig(nil, "", time.Now(), f.logger, f.defaultUser, f.overrides)
+		if err != nil {
+			return nil, "", err
+		}
+		return cfg, "", nil
+	}
 	cfg, newBaseURL, err := f.fetchHTTP(ctx, baseURL, prevConfig)
 	if err == nil {
 		return cfg, newBaseURL, nil

--- a/v7/flag.go
+++ b/v7/flag.go
@@ -94,8 +94,11 @@ func (f IntFlag) Get(snap *Snapshot) int {
 // GetValue implements Flag.GetValue.
 func (f IntFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
-	if _, ok := v.(int); ok {
+	switch v1 := v.(type) {
+	case int:
 		return v
+	case float64:
+		return int(v1)
 	}
 	return f.defaultValue
 }
@@ -170,11 +173,8 @@ func (f FloatFlag) Get(snap *Snapshot) float64 {
 // GetValue implements Flag.GetValue.
 func (f FloatFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
-	switch result := v.(type) {
-	case int:
-		return float64(result)
-	case float64:
-		return result
+	if _, ok := v.(float64); ok {
+		return v
 	}
 	return f.defaultValue
 }

--- a/v7/flag_overrides_test.go
+++ b/v7/flag_overrides_test.go
@@ -2,9 +2,10 @@ package configcat
 
 import (
 	"context"
+	"testing"
+
 	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 	qt "github.com/frankban/quicktest"
-	"testing"
 )
 
 func TestFlagOverrides_File_Simple(t *testing.T) {
@@ -77,7 +78,7 @@ func TestFlagOverrides_Values_LocalOnly(t *testing.T) {
 	c.Assert(client.GetStringValue("stringSetting", "", nil), qt.Equals, "test")
 }
 
-func TestFlagOverrides_Values_Ignored_On_Wrong_Behaviour(t *testing.T) {
+func TestFlagOverrides_Values_Ignored_On_Wrong_Behavior(t *testing.T) {
 	c := qt.New(t)
 	cfg := Config{
 		FlagOverrides: &FlagOverrides{
@@ -88,7 +89,7 @@ func TestFlagOverrides_Values_Ignored_On_Wrong_Behaviour(t *testing.T) {
 				"doubleSetting":   3.14,
 				"stringSetting":   "test",
 			},
-			Behaviour: 5,
+			Behavior: 5,
 		},
 	}
 	client := NewCustomClient(cfg)
@@ -112,7 +113,7 @@ func TestFlagOverrides_Values_LocalOverRemote(t *testing.T) {
 			"fakeKey":     true,
 			"nonexisting": true,
 		},
-		Behaviour: LocalOverRemote,
+		Behavior: LocalOverRemote,
 	}
 
 	client := NewCustomClient(cfg)
@@ -135,7 +136,7 @@ func TestFlagOverrides_Values_RemoteOverLocal(t *testing.T) {
 			"fakeKey":     true,
 			"nonexisting": true,
 		},
-		Behaviour: RemoteOverLocal,
+		Behavior: RemoteOverLocal,
 	}
 
 	client := NewCustomClient(cfg)
@@ -158,7 +159,7 @@ func TestFlagOverrides_Values_Remote_Invalid(t *testing.T) {
 			"fakeKey": true,
 			"invalid": BoolFlag{},
 		},
-		Behaviour: RemoteOverLocal,
+		Behavior: RemoteOverLocal,
 	}
 
 	client := NewCustomClient(cfg)
@@ -181,7 +182,7 @@ func TestFlagOverrides_Values_Local_Invalid(t *testing.T) {
 			"fakeKey": true,
 			"invalid": BoolFlag{},
 		},
-		Behaviour: LocalOnly,
+		Behavior: LocalOnly,
 	}
 
 	client := NewCustomClient(cfg)
@@ -189,6 +190,6 @@ func TestFlagOverrides_Values_Local_Invalid(t *testing.T) {
 	err := client.Refresh(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
-	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsFalse)
+	c.Assert(client.GetBoolValue("fakeKey", false, nil), qt.IsTrue)
 	c.Assert(client.GetBoolValue("invalid", false, nil), qt.IsFalse)
 }

--- a/v7/policy_test.go
+++ b/v7/policy_test.go
@@ -11,7 +11,7 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-// TestFetchFailWithCacheFallback tests that cache fallback behaviour
+// TestFetchFailWithCacheFallback tests that cache fallback behavior
 // works as expected.
 func TestFetchFailWithCacheFallback(t *testing.T) {
 	c := qt.New(t)


### PR DESCRIPTION
This PR makes a few changes to the logic proposed in PR #52,
some of which were a bit hard to suggest as comments, hence
I'm proposing them as code. Note the target of this PR (not master!).

- rename `Behaviour` to `Behavior` (US spelling is standard in Go)
- simplify the override parser so that it's only concerned with creating a set of entries, and not with creating a snapshot.
- use the regular config fetcher even in local-only mode (this also makes it easier for us to
add polling for the local override file changing in the future if we want)

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
