### PR TITLE
v7: minor tweaks to override code

### DIFF
--- a/v7/flag.go
+++ b/v7/flag.go
@@ -98,6 +98,9 @@ func (f IntFlag) GetValue(snap *Snapshot) interface{} {
 	case int:
 		return v
 	case float64:
+		// This can happen when a numeric override flag is used
+		// with SimplifiedConfig, which can't tell the difference
+		// between int and float64.
 		return int(v1)
 	}
 	return f.defaultValue

--- a/v7/snapshot.go
+++ b/v7/snapshot.go
@@ -280,16 +280,12 @@ func (snap *Snapshot) GetAllKeys() []string {
 	return snap.allKeys
 }
 
-// GetAllValues returns all keys and values in a key-value map.
+// GetAllValues returns all keys and values in freshly allocated key-value map.
 func (snap *Snapshot) GetAllValues() map[string]interface{} {
-	if snap == nil || snap.config == nil {
-		return nil
-	}
-	keys := snap.config.keys()
+	keys := snap.GetAllKeys()
 	values := make(map[string]interface{}, len(keys))
 	for _, key := range keys {
-		id := idForKey(key, false)
-		values[key] = snap.value(id, key)
+		values[key] = snap.GetValue(key)
 	}
 	return values
 }


### PR DESCRIPTION
- avoid checking for nil fetcher (it's always present)
- set types of entries even when reading override config from full file (making it easier for people to make a valid config file)
- add a couple of tests to check the edge-case behaviour of int vs float when overriding
- simplify `Snapshot.GetAllValues`
- doc tweaks

### Describe the purpose of your pull request

Provide a clear and concise description of the changes.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
