### PR TITLE
feat(snapshot): Expose config FetchTime for snapshots

### DIFF
--- a/v7/configcat_client_test.go
+++ b/v7/configcat_client_test.go
@@ -535,7 +535,14 @@ func TestSnapshot_Get(t *testing.T) {
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(rootNodeWithKeyValue("key", 99, wireconfig.IntEntry))
 	client.Refresh(context.Background())
-	c.Check(client.Snapshot(nil).GetValue("key"), qt.Equals, 99)
+	snap := client.Snapshot(nil)
+	c.Check(snap.GetValue("key"), qt.Equals, 99)
+	c.Check(snap.FetchTime(), qt.Not(qt.Equals), time.Time{})
+	srv.setResponseJSON(rootNodeWithKeyValue("key", 101, wireconfig.IntEntry))
+	client.Refresh(context.Background())
+	c.Check(snap.GetValue("key"), qt.Equals, 99)
+	c.Check(client.Snapshot(nil).GetValue("key"), qt.Equals, 101)
+	c.Check(client.Snapshot(nil).FetchTime().After(snap.FetchTime()), qt.IsTrue)
 }
 
 type failingCache struct{}

--- a/v7/snapshot.go
+++ b/v7/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Snapshot holds a snapshot of the Configcat configuration.
@@ -288,4 +289,11 @@ func (snap *Snapshot) GetAllValues() map[string]interface{} {
 		values[key] = snap.GetValue(key)
 	}
 	return values
+}
+
+func (snap *Snapshot) FetchTime() time.Time {
+	if snap == nil || snap.config == nil {
+		return time.Time{}
+	}
+	return snap.config.fetchTime
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

The following exposes the underlying config fetchTime so it's possible to
know when a given snapshot was taken. As snapshots act like readonly
encapsulations around configs, it's important to know if they're up to
date or not.

### Related issues (only if applicable)

N/A

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
