### PR TITLE
Evaluation details

### DIFF
--- a/v7/config_fetcher.go
+++ b/v7/config_fetcher.go
@@ -31,6 +31,7 @@ type configFetcher struct {
 	defaultUser       User
 	pollingIdentifier string
 	overrides         *FlagOverrides
+	hooks             *Hooks
 
 	ctx       context.Context
 	ctxCancel func()
@@ -61,6 +62,7 @@ func newConfigFetcher(cfg Config, logger *leveledLogger, defaultUser User) *conf
 		cacheKey:     sdkKeyToCacheKey(cfg.SDKKey),
 		overrides:    cfg.FlagOverrides,
 		changeNotify: cfg.ChangeNotify,
+		hooks:        cfg.Hooks,
 		logger:       logger,
 		client: &http.Client{
 			Timeout:   cfg.HTTPTimeout,
@@ -184,6 +186,9 @@ func (f *configFetcher) fetcher(prevConfig *config, logError bool) {
 		if f.changeNotify != nil && !config.equalContent(prevConfig) {
 			go f.changeNotify()
 		}
+		if f.hooks != nil && f.hooks.OnConfigChanged != nil && !config.equalContent(prevConfig) {
+			go f.hooks.OnConfigChanged(config.root.Entries)
+		}
 	}
 	// Unblock any Client.getValue call that's waiting for the first configuration to be retrieved.
 	f.doneGetOnce.Do(func() {
@@ -196,7 +201,7 @@ func (f *configFetcher) fetcher(prevConfig *config, logError bool) {
 func (f *configFetcher) fetchConfig(ctx context.Context, baseURL string, prevConfig *config) (_ *config, _newURL string, _err error) {
 	if f.overrides != nil && f.overrides.Behavior == LocalOnly {
 		// TODO could potentially refresh f.overrides if it's come from a file.
-		cfg, err := parseConfig(nil, "", time.Now(), f.logger, f.defaultUser, f.overrides)
+		cfg, err := parseConfig(nil, "", time.Now(), f.logger, f.defaultUser, f.overrides, f.hooks)
 		if err != nil {
 			return nil, "", err
 		}
@@ -220,7 +225,7 @@ func (f *configFetcher) fetchConfig(ctx context.Context, baseURL string, prevCon
 		f.logger.Debugf("empty config text in cache")
 		return nil, "", err
 	}
-	cfg, cacheErr = parseConfig(configText, "", time.Time{}, f.logger, f.defaultUser, f.overrides)
+	cfg, cacheErr = parseConfig(configText, "", time.Time{}, f.logger, f.defaultUser, f.overrides, f.hooks)
 	if cacheErr != nil {
 		f.logger.Errorf("cache contained invalid config: %v", err)
 		return nil, "", err
@@ -301,7 +306,7 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 	if f.sdkKey == "" {
 		return nil, fmt.Errorf("empty SDK key in configcat configuration")
 	}
-	request, err := http.NewRequest("GET", baseURL+"/configuration-files/"+f.sdkKey+"/"+configJSONName+".json", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/configuration-files/"+f.sdkKey+"/"+configJSONName+".json", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +332,7 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 		if err != nil {
 			return nil, fmt.Errorf("config fetch read failed: %v", err)
 		}
-		config, err := parseConfig(body, response.Header.Get("Etag"), time.Now(), f.logger, f.defaultUser, f.overrides)
+		config, err := parseConfig(body, response.Header.Get("Etag"), time.Now(), f.logger, f.defaultUser, f.overrides, f.hooks)
 		if err != nil {
 			return nil, fmt.Errorf("config fetch returned invalid body: %v", err)
 		}

--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -3,12 +3,25 @@ package configcat
 
 import (
 	"context"
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
 	"net/http"
 	"sync"
 	"time"
 )
 
 const DefaultPollInterval = 60 * time.Second
+
+// Hooks describes the events sent by Client.
+type Hooks struct {
+	// OnFlagEvaluated is called each time when the SDK evaluates a feature flag or setting.
+	OnFlagEvaluated func(details *EvaluationDetails)
+
+	// OnError is called when an error occurs within the ConfigCat SDK.
+	OnError func(err error)
+
+	// OnConfigChanged is called, when the settings configuration has changed.
+	OnConfigChanged func(map[string]*wireconfig.Entry)
+}
 
 // Config describes configuration options for the Client.
 type Config struct {
@@ -64,6 +77,7 @@ type Config struct {
 
 	// ChangeNotify is called, if not nil, when the settings configuration
 	// has changed.
+	// Deprecated: Use Hooks instead.
 	ChangeNotify func()
 
 	// DataGovernance specifies the data governance mode.
@@ -85,6 +99,9 @@ type Config struct {
 
 	// FlagOverrides holds the feature flag and setting overrides.
 	FlagOverrides *FlagOverrides
+
+	// Hooks controls the events sent by Client.
+	Hooks *Hooks
 }
 
 // ConfigCache is a cache API used to make custom cache implementations.
@@ -292,5 +309,5 @@ func (client *Client) Snapshot(user User) *Snapshot {
 			})
 		}
 	}
-	return newSnapshot(client.fetcher.current(), user, client.logger)
+	return newSnapshot(client.fetcher.current(), user, client.logger, client.cfg.Hooks)
 }

--- a/v7/configcat_client.go
+++ b/v7/configcat_client.go
@@ -200,9 +200,25 @@ func (client *Client) GetBoolValue(key string, defaultValue bool, user User) boo
 	return Bool(key, defaultValue).Get(client.Snapshot(user))
 }
 
+// GetBoolValueDetails returns the value and evaluation details of a boolean-typed feature flag.
+// If user is non-nil, it will be used to choose the value (see the User documentation for details).
+// If user is nil and Config.DefaultUser was non-nil, that will be used instead.
+//
+// In Lazy refresh mode, this can block indefinitely while the configuration
+// is fetched. Use RefreshIfOlder explicitly if explicit control of timeouts
+// is needed.
+func (client *Client) GetBoolValueDetails(key string, defaultValue bool, user User) BoolEvaluationDetails {
+	return Bool(key, defaultValue).GetWithDetails(client.Snapshot(user))
+}
+
 // GetIntValue is like GetBoolValue except for int-typed (whole number) feature flags.
 func (client *Client) GetIntValue(key string, defaultValue int, user User) int {
 	return Int(key, defaultValue).Get(client.Snapshot(user))
+}
+
+// GetIntValueDetails is like GetBoolValueDetails except for int-typed (whole number) feature flags.
+func (client *Client) GetIntValueDetails(key string, defaultValue int, user User) IntEvaluationDetails {
+	return Int(key, defaultValue).GetWithDetails(client.Snapshot(user))
 }
 
 // GetFloatValue is like GetBoolValue except for float-typed (decimal number) feature flags.
@@ -210,9 +226,19 @@ func (client *Client) GetFloatValue(key string, defaultValue float64, user User)
 	return Float(key, defaultValue).Get(client.Snapshot(user))
 }
 
+// GetFloatValueDetails is like GetBoolValueDetails except for float-typed (decimal number) feature flags.
+func (client *Client) GetFloatValueDetails(key string, defaultValue float64, user User) FloatEvaluationDetails {
+	return Float(key, defaultValue).GetWithDetails(client.Snapshot(user))
+}
+
 // GetStringValue is like GetBoolValue except for string-typed (text) feature flags.
 func (client *Client) GetStringValue(key string, defaultValue string, user User) string {
 	return String(key, defaultValue).Get(client.Snapshot(user))
+}
+
+// GetStringValueDetails is like GetBoolValueDetails except for string-typed (text) feature flags.
+func (client *Client) GetStringValueDetails(key string, defaultValue string, user User) StringEvaluationDetails {
+	return String(key, defaultValue).GetWithDetails(client.Snapshot(user))
 }
 
 // GetVariationID returns the variation ID (analytics) that will be used for the given key

--- a/v7/configcat_client_test.go
+++ b/v7/configcat_client_test.go
@@ -564,7 +564,7 @@ func TestClient_GetBoolDetails(t *testing.T) {
 	c.Assert(details.Meta.User, qt.Equals, user)
 	c.Assert(details.Meta.VariationId, qt.Equals, "385d9803")
 	c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
-	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpOneOf)
+	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, 0)
 	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
 	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "a@configcat.com, b@configcat.com")
 }
@@ -588,7 +588,7 @@ func TestClient_GetStringDetails(t *testing.T) {
 	c.Assert(details.Meta.User, qt.Equals, user)
 	c.Assert(details.Meta.VariationId, qt.Equals, "d0cd8f06")
 	c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
-	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpContains)
+	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, 2)
 	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
 	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "@configcat.com")
 }
@@ -633,9 +633,25 @@ func TestClient_GetFloatDetails(t *testing.T) {
 	c.Assert(details.Meta.User, qt.Equals, user)
 	c.Assert(details.Meta.VariationId, qt.Equals, "3f7826de")
 	c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
-	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpContains)
+	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, 2)
 	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
 	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "@configcat.com")
+}
+
+func TestClient_GetAllDetails(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+	client := NewCustomClient(srv.config())
+	client.Refresh(context.Background())
+
+	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
+
+	keys := client.GetAllKeys()
+	details := client.GetAllValueDetails(user)
+	c.Assert(len(details), qt.Equals, len(keys))
 }
 
 func TestClient_GetDetails_Reflected_User(t *testing.T) {
@@ -672,7 +688,7 @@ func TestClient_Hooks_OnFlagEvaluated(t *testing.T) {
 		c.Assert(details.Meta.User, qt.Equals, user)
 		c.Assert(details.Meta.VariationId, qt.Equals, "3f7826de")
 		c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
-		c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpContains)
+		c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, 2)
 		c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
 		c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "@configcat.com")
 		called <- struct{}{}

--- a/v7/configcat_client_test.go
+++ b/v7/configcat_client_test.go
@@ -545,6 +545,150 @@ func TestSnapshot_Get(t *testing.T) {
 	c.Check(client.Snapshot(nil).FetchTime().After(snap.FetchTime()), qt.IsTrue)
 }
 
+func TestClient_GetBoolDetails(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+	client := NewCustomClient(srv.config())
+	client.Refresh(context.Background())
+
+	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
+
+	details := client.GetBoolValueDetails("bool30TrueAdvancedRules", true, user)
+	c.Assert(details.Value, qt.IsFalse)
+	c.Assert(details.Meta.IsDefaultValue, qt.IsFalse)
+	c.Assert(details.Meta.Error, qt.IsNil)
+	c.Assert(details.Meta.Key, qt.Equals, "bool30TrueAdvancedRules")
+	c.Assert(details.Meta.User, qt.Equals, user)
+	c.Assert(details.Meta.VariationId, qt.Equals, "385d9803")
+	c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
+	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpOneOf)
+	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
+	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "a@configcat.com, b@configcat.com")
+}
+
+func TestClient_GetStringDetails(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+	client := NewCustomClient(srv.config())
+	client.Refresh(context.Background())
+
+	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
+
+	details := client.GetStringValueDetails("stringContainsDogDefaultCat", "", user)
+	c.Assert(details.Value, qt.Equals, "Dog")
+	c.Assert(details.Meta.IsDefaultValue, qt.IsFalse)
+	c.Assert(details.Meta.Error, qt.IsNil)
+	c.Assert(details.Meta.Key, qt.Equals, "stringContainsDogDefaultCat")
+	c.Assert(details.Meta.User, qt.Equals, user)
+	c.Assert(details.Meta.VariationId, qt.Equals, "d0cd8f06")
+	c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
+	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpContains)
+	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
+	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "@configcat.com")
+}
+
+func TestClient_GetIntDetails(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+	client := NewCustomClient(srv.config())
+	client.Refresh(context.Background())
+
+	user := &UserData{Identifier: "a@configcat.com"}
+
+	details := client.GetIntValueDetails("integer25One25Two25Three25FourAdvancedRules", 0, user)
+	c.Assert(details.Value, qt.Equals, 1)
+	c.Assert(details.Meta.IsDefaultValue, qt.IsFalse)
+	c.Assert(details.Meta.Error, qt.IsNil)
+	c.Assert(details.Meta.Key, qt.Equals, "integer25One25Two25Three25FourAdvancedRules")
+	c.Assert(details.Meta.User, qt.Equals, user)
+	c.Assert(details.Meta.VariationId, qt.Equals, "11634414")
+	c.Assert(details.Meta.MatchedEvaluationPercentageRule.Percentage, qt.Equals, int64(25))
+}
+
+func TestClient_GetFloatDetails(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+	client := NewCustomClient(srv.config())
+	client.Refresh(context.Background())
+
+	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
+
+	details := client.GetFloatValueDetails("double25Pi25E25Gr25Zero", 0.0, user)
+	c.Assert(details.Value, qt.Equals, 5.561)
+	c.Assert(details.Meta.IsDefaultValue, qt.IsFalse)
+	c.Assert(details.Meta.Error, qt.IsNil)
+	c.Assert(details.Meta.Key, qt.Equals, "double25Pi25E25Gr25Zero")
+	c.Assert(details.Meta.User, qt.Equals, user)
+	c.Assert(details.Meta.VariationId, qt.Equals, "3f7826de")
+	c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
+	c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpContains)
+	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
+	c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "@configcat.com")
+}
+
+func TestClient_GetDetails_Reflected_User(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+	client := NewCustomClient(srv.config())
+	client.Refresh(context.Background())
+
+	user := &struct{ attr string }{"a"}
+
+	details := client.GetFloatValueDetails("double25Pi25E25Gr25Zero", 0.0, user)
+	c.Assert(details.Meta.User, qt.Equals, user)
+}
+
+func TestClient_Hooks_OnFlagEvaluated(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
+	})
+
+	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
+
+	called := make(chan struct{})
+	cfg := srv.config()
+	cfg.Hooks = &Hooks{OnFlagEvaluated: func(details *EvaluationDetails) {
+		c.Assert(details.Value, qt.Equals, 5.561)
+		c.Assert(details.Meta.IsDefaultValue, qt.IsFalse)
+		c.Assert(details.Meta.Error, qt.IsNil)
+		c.Assert(details.Meta.Key, qt.Equals, "double25Pi25E25Gr25Zero")
+		c.Assert(details.Meta.User, qt.Equals, user)
+		c.Assert(details.Meta.VariationId, qt.Equals, "3f7826de")
+		c.Assert(details.Meta.MatchedEvaluationPercentageRule, qt.IsNil)
+		c.Assert(details.Meta.MatchedEvaluationRule.Comparator, qt.Equals, wireconfig.OpContains)
+		c.Assert(details.Meta.MatchedEvaluationRule.ComparisonAttribute, qt.Equals, "Email")
+		c.Assert(details.Meta.MatchedEvaluationRule.ComparisonValue, qt.Equals, "@configcat.com")
+		called <- struct{}{}
+	}}
+	client := NewCustomClient(cfg)
+	client.Refresh(context.Background())
+
+	_ = client.GetFloatValue("double25Pi25E25Gr25Zero", 0.0, user)
+
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out")
+	}
+}
+
 type failingCache struct{}
 
 // get reads the configuration from the cache.

--- a/v7/configserver_test.go
+++ b/v7/configserver_test.go
@@ -18,9 +18,10 @@ type configServer struct {
 	key string
 	t   testing.TB
 
-	mu        sync.Mutex
-	resp      *configResponse
-	responses []configResponse
+	mu           sync.Mutex
+	resp         *configResponse
+	responses    []configResponse
+	requestCount int
 }
 
 type configResponse struct {
@@ -89,6 +90,7 @@ func (srv *configServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	srv.mu.Lock()
+	srv.requestCount++
 	resp0 := srv.resp
 	defer srv.mu.Unlock()
 	if resp0 == nil {

--- a/v7/eval.go
+++ b/v7/eval.go
@@ -36,7 +36,7 @@ func (conf *config) evaluatorsForUserType(userType reflect.Type) ([]entryEvalFun
 	return entries1.([]entryEvalFunc), nil
 }
 
-type entryEvalFunc = func(id keyID, logger *leveledLogger, userv reflect.Value) (int32, string)
+type entryEvalFunc = func(id keyID, logger *leveledLogger, userv reflect.Value) int32
 
 func entryEvaluators(root *wireconfig.RootNode, userType reflect.Type) ([]entryEvalFunc, error) {
 	tinfo, err := newUserTypeInfo(userType)
@@ -59,13 +59,13 @@ func entryEvaluators(root *wireconfig.RootNode, userType reflect.Type) ([]entryE
 
 func entryEvaluator(key string, node *wireconfig.Entry, tinfo *userTypeInfo) entryEvalFunc {
 	rules := node.RolloutRules
-	noUser := func(_ keyID, logger *leveledLogger, user reflect.Value) (valueID, string) {
+	noUser := func(_ keyID, logger *leveledLogger, user reflect.Value) valueID {
 		if logger.enabled(LogLevelWarn) && (len(rules) > 0 || len(node.PercentageRules) > 0) {
 			logger.Warnf("Evaluating GetValue(%s). UserObject missing! You should pass a "+
 				"UserObject to GetValueForUser() in order to make targeting work properly. "+
 				"Read more: https://configcat.com/docs/advanced/user-object.", key)
 		}
-		return node.ValueID, node.VariationID
+		return node.ValueID
 	}
 
 	if tinfo == nil {
@@ -81,7 +81,7 @@ func entryEvaluator(key string, node *wireconfig.Entry, tinfo *userTypeInfo) ent
 	identifierInfo := tinfo.attrInfo("Identifier")
 	keyBytes := []byte(key)
 
-	return func(id keyID, logger *leveledLogger, userv reflect.Value) (valueID, string) {
+	return func(id keyID, logger *leveledLogger, userv reflect.Value) valueID {
 		if tinfo.deref {
 			if userv.IsNil() {
 				return noUser(id, logger, userv)
@@ -100,7 +100,7 @@ func entryEvaluator(key string, node *wireconfig.Entry, tinfo *userTypeInfo) ent
 						rule.ComparisonValue,
 					)
 				}
-				return rule.ValueID, rule.VariationID
+				return rule.ValueID
 			}
 			if err != nil {
 				if logger.enabled(LogLevelInfo) {
@@ -139,11 +139,11 @@ func entryEvaluator(key string, node *wireconfig.Entry, tinfo *userTypeInfo) ent
 			for _, rule := range node.PercentageRules {
 				bucket += rule.Percentage
 				if scaled < bucket {
-					return rule.ValueID, rule.VariationID
+					return rule.ValueID
 				}
 			}
 		}
-		return node.ValueID, node.VariationID
+		return node.ValueID
 	}
 }
 

--- a/v7/eval_details.go
+++ b/v7/eval_details.go
@@ -13,8 +13,8 @@ type EvaluationDetailsMeta struct {
 	IsDefaultValue                  bool
 	Error                           error
 	FetchTime                       time.Time
-	MatchedEvaluationRule           *wireconfig.RolloutRule
-	MatchedEvaluationPercentageRule *wireconfig.PercentageRule
+	MatchedEvaluationRule           *RolloutRule
+	MatchedEvaluationPercentageRule *PercentageRule
 }
 
 // EvaluationDetails holds the additional evaluation information along with the value of a feature flag or setting.
@@ -45,4 +45,34 @@ type StringEvaluationDetails struct {
 type FloatEvaluationDetails struct {
 	Meta  EvaluationDetailsMeta
 	Value float64
+}
+
+type RolloutRule struct {
+	ComparisonAttribute string
+	ComparisonValue     string
+	Comparator          int
+}
+
+type PercentageRule struct {
+	VariationID string
+	Percentage  int64
+}
+
+func newPublicRolloutRuleOrNil(rule *wireconfig.RolloutRule) *RolloutRule {
+	if rule == nil {
+		return nil
+	}
+
+	return &RolloutRule{
+		Comparator:          int(rule.Comparator),
+		ComparisonAttribute: rule.ComparisonAttribute,
+		ComparisonValue:     rule.ComparisonValue}
+}
+
+func newPublicPercentageRuleOrNil(rule *wireconfig.PercentageRule) *PercentageRule {
+	if rule == nil {
+		return nil
+	}
+
+	return &PercentageRule{Percentage: rule.Percentage}
 }

--- a/v7/eval_details.go
+++ b/v7/eval_details.go
@@ -13,8 +13,8 @@ type EvaluationDetailsMeta struct {
 	IsDefaultValue                  bool
 	Error                           error
 	FetchTime                       time.Time
-	MatchedEvaluationRule           wireconfig.RolloutRule
-	MatchedEvaluationPercentageRule wireconfig.PercentageRule
+	MatchedEvaluationRule           *wireconfig.RolloutRule
+	MatchedEvaluationPercentageRule *wireconfig.PercentageRule
 }
 
 // EvaluationDetails holds the additional evaluation information along with the value of a feature flag or setting.

--- a/v7/eval_details.go
+++ b/v7/eval_details.go
@@ -1,0 +1,48 @@
+package configcat
+
+import (
+	"github.com/configcat/go-sdk/v7/internal/wireconfig"
+	"time"
+)
+
+// EvaluationDetailsMeta holds the additional evaluation information of a feature flag or setting.
+type EvaluationDetailsMeta struct {
+	Key                             string
+	VariationId                     string
+	User                            User
+	IsDefaultValue                  bool
+	Error                           error
+	FetchTime                       time.Time
+	MatchedEvaluationRule           wireconfig.RolloutRule
+	MatchedEvaluationPercentageRule wireconfig.PercentageRule
+}
+
+// EvaluationDetails holds the additional evaluation information along with the value of a feature flag or setting.
+type EvaluationDetails struct {
+	Meta  EvaluationDetailsMeta
+	Value interface{}
+}
+
+// BoolEvaluationDetails holds the additional evaluation information along with the value of a bool flag.
+type BoolEvaluationDetails struct {
+	Meta  EvaluationDetailsMeta
+	Value bool
+}
+
+// IntEvaluationDetails holds the additional evaluation information along with the value of a whole number flag.
+type IntEvaluationDetails struct {
+	Meta  EvaluationDetailsMeta
+	Value int
+}
+
+// StringEvaluationDetails holds the additional evaluation information along with the value of a string flag.
+type StringEvaluationDetails struct {
+	Meta  EvaluationDetailsMeta
+	Value string
+}
+
+// FloatEvaluationDetails holds the additional evaluation information along with the value of a decimal number flag.
+type FloatEvaluationDetails struct {
+	Meta  EvaluationDetailsMeta
+	Value float64
+}

--- a/v7/flag.go
+++ b/v7/flag.go
@@ -1,6 +1,8 @@
 package configcat
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 )
 
@@ -12,6 +14,11 @@ type Flag interface {
 	// GetValue returns the flag's value. It will always
 	// return the appropriate type for the flag (never nil).
 	GetValue(snap *Snapshot) interface{}
+
+	// GetValueDetails returns the evaluation details
+	// along with the flag's value. Its Value field always
+	// have the appropriate type for the flag.
+	GetValueDetails(snap *Snapshot) EvaluationDetails
 }
 
 // Bool returns a representation of a boolean-valued flag.
@@ -53,6 +60,14 @@ func (f BoolFlag) Get(snap *Snapshot) bool {
 	return f.GetValue(snap).(bool)
 }
 
+// GetWithDetails returns the evaluation details along with the flag's value.
+// It returns BoolEvaluationDetails with the flag's default value if snap is nil
+// or the key isn't in the configuration.
+func (f BoolFlag) GetWithDetails(snap *Snapshot) BoolEvaluationDetails {
+	details := f.GetValueDetails(snap)
+	return BoolEvaluationDetails{Meta: details.Meta, Value: details.Value.(bool)}
+}
+
 // GetValue implements Flag.GetValue.
 func (f BoolFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
@@ -60,6 +75,26 @@ func (f BoolFlag) GetValue(snap *Snapshot) interface{} {
 		return v
 	}
 	return f.defaultValue
+}
+
+// GetValueDetails implements Flag.GetValueDetails.
+func (f BoolFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
+	details := snap.evalDetailsForKeyId(f.id, f.key)
+	boolVal, ok := details.Value.(bool)
+	if !ok {
+		return EvaluationDetails{
+			Value: f.defaultValue,
+			Meta: EvaluationDetailsMeta{
+				Key:            f.key,
+				Error:          errors.New(fmt.Sprintf("could not convert %s to bool", details.Value)),
+				User:           snap.originalUser,
+				FetchTime:      snap.FetchTime(),
+				IsDefaultValue: true,
+			},
+		}
+	}
+	details.Value = boolVal
+	return details
 }
 
 // Int is like Bool but for int-valued flags.
@@ -91,19 +126,41 @@ func (f IntFlag) Get(snap *Snapshot) int {
 	return f.GetValue(snap).(int)
 }
 
+// GetWithDetails returns the evaluation details along with the flag's value.
+// It returns IntEvaluationDetails with the flag's default value if snap is nil
+// or the key isn't in the configuration.
+func (f IntFlag) GetWithDetails(snap *Snapshot) IntEvaluationDetails {
+	details := f.GetValueDetails(snap)
+	return IntEvaluationDetails{Meta: details.Meta, Value: details.Value.(int)}
+}
+
 // GetValue implements Flag.GetValue.
 func (f IntFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
-	switch v1 := v.(type) {
-	case int:
-		return v
-	case float64:
-		// This can happen when a numeric override flag is used
-		// with SimplifiedConfig, which can't tell the difference
-		// between int and float64.
-		return int(v1)
+	if res, ok := convertInt(v); ok {
+		return res
 	}
 	return f.defaultValue
+}
+
+// GetValueDetails implements Flag.GetValueDetails.
+func (f IntFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
+	details := snap.evalDetailsForKeyId(f.id, f.key)
+	intVal, ok := convertInt(details.Value)
+	if !ok {
+		return EvaluationDetails{
+			Value: f.defaultValue,
+			Meta: EvaluationDetailsMeta{
+				Key:            f.key,
+				Error:          errors.New(fmt.Sprintf("could not convert %s to int", details.Value)),
+				User:           snap.originalUser,
+				FetchTime:      snap.FetchTime(),
+				IsDefaultValue: true,
+			},
+		}
+	}
+	details.Value = intVal
+	return details
 }
 
 // String is like Bool but for string-valued flags.
@@ -135,6 +192,14 @@ func (f StringFlag) Get(snap *Snapshot) string {
 	return f.GetValue(snap).(string)
 }
 
+// GetWithDetails returns the evaluation details along with the flag's value.
+// It returns StringEvaluationDetails with the flag's default value if snap is nil
+// or the key isn't in the configuration.
+func (f StringFlag) GetWithDetails(snap *Snapshot) StringEvaluationDetails {
+	details := f.GetValueDetails(snap)
+	return StringEvaluationDetails{Meta: details.Meta, Value: details.Value.(string)}
+}
+
 // GetValue implements Flag.GetValue.
 func (f StringFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
@@ -142,6 +207,26 @@ func (f StringFlag) GetValue(snap *Snapshot) interface{} {
 		return v
 	}
 	return f.defaultValue
+}
+
+// GetValueDetails implements Flag.GetValueDetails.
+func (f StringFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
+	details := snap.evalDetailsForKeyId(f.id, f.key)
+	stringVal, ok := details.Value.(string)
+	if !ok {
+		return EvaluationDetails{
+			Value: f.defaultValue,
+			Meta: EvaluationDetailsMeta{
+				Key:            f.key,
+				Error:          errors.New(fmt.Sprintf("could not convert %s to string", details.Value)),
+				User:           snap.originalUser,
+				FetchTime:      snap.FetchTime(),
+				IsDefaultValue: true,
+			},
+		}
+	}
+	details.Value = stringVal
+	return details
 }
 
 // Float is like Bool but for float-valued flags.
@@ -173,6 +258,14 @@ func (f FloatFlag) Get(snap *Snapshot) float64 {
 	return f.GetValue(snap).(float64)
 }
 
+// GetWithDetails returns the evaluation details along with the flag's value.
+// It returns FloatEvaluationDetails with the flag's default value if snap is nil
+// or the key isn't in the configuration.
+func (f FloatFlag) GetWithDetails(snap *Snapshot) FloatEvaluationDetails {
+	details := f.GetValueDetails(snap)
+	return FloatEvaluationDetails{Meta: details.Meta, Value: details.Value.(float64)}
+}
+
 // GetValue implements Flag.GetValue.
 func (f FloatFlag) GetValue(snap *Snapshot) interface{} {
 	v := snap.value(f.id, f.key)
@@ -180,6 +273,26 @@ func (f FloatFlag) GetValue(snap *Snapshot) interface{} {
 		return v
 	}
 	return f.defaultValue
+}
+
+// GetValueDetails implements Flag.GetValueDetails.
+func (f FloatFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
+	details := snap.evalDetailsForKeyId(f.id, f.key)
+	floatVal, ok := details.Value.(float64)
+	if !ok {
+		return EvaluationDetails{
+			Value: f.defaultValue,
+			Meta: EvaluationDetailsMeta{
+				Key:            f.key,
+				Error:          errors.New(fmt.Sprintf("could not convert %s to float64", details.Value)),
+				User:           snap.originalUser,
+				FetchTime:      snap.FetchTime(),
+				IsDefaultValue: true,
+			},
+		}
+	}
+	details.Value = floatVal
+	return details
 }
 
 type keyID uint32
@@ -216,4 +329,17 @@ func numKeys() int {
 	keyIDs.mu.Lock()
 	defer keyIDs.mu.Unlock()
 	return int(keyIDs.max)
+}
+
+func convertInt(val interface{}) (interface{}, bool) {
+	switch v1 := val.(type) {
+	case int:
+		return val, true
+	case float64:
+		// This can happen when a numeric override flag is used
+		// with SimplifiedConfig, which can't tell the difference
+		// between int and float64.
+		return int(v1), true
+	}
+	return nil, false
 }

--- a/v7/flag.go
+++ b/v7/flag.go
@@ -1,7 +1,6 @@
 package configcat
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 )
@@ -86,7 +85,7 @@ func (f BoolFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
 			Value: f.defaultValue,
 			Meta: EvaluationDetailsMeta{
 				Key:            f.key,
-				Error:          errors.New(fmt.Sprintf("could not convert %s to bool", details.Value)),
+				Error:          fmt.Errorf("could not convert %s to bool", details.Value),
 				User:           snap.originalUser,
 				FetchTime:      snap.FetchTime(),
 				IsDefaultValue: true,
@@ -152,7 +151,7 @@ func (f IntFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
 			Value: f.defaultValue,
 			Meta: EvaluationDetailsMeta{
 				Key:            f.key,
-				Error:          errors.New(fmt.Sprintf("could not convert %s to int", details.Value)),
+				Error:          fmt.Errorf("could not convert %s to int", details.Value),
 				User:           snap.originalUser,
 				FetchTime:      snap.FetchTime(),
 				IsDefaultValue: true,
@@ -218,7 +217,7 @@ func (f StringFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
 			Value: f.defaultValue,
 			Meta: EvaluationDetailsMeta{
 				Key:            f.key,
-				Error:          errors.New(fmt.Sprintf("could not convert %s to string", details.Value)),
+				Error:          fmt.Errorf("could not convert %s to string", details.Value),
 				User:           snap.originalUser,
 				FetchTime:      snap.FetchTime(),
 				IsDefaultValue: true,
@@ -284,7 +283,7 @@ func (f FloatFlag) GetValueDetails(snap *Snapshot) EvaluationDetails {
 			Value: f.defaultValue,
 			Meta: EvaluationDetailsMeta{
 				Key:            f.key,
-				Error:          errors.New(fmt.Sprintf("could not convert %s to float64", details.Value)),
+				Error:          fmt.Errorf("could not convert %s to float64", details.Value),
 				User:           snap.originalUser,
 				FetchTime:      snap.FetchTime(),
 				IsDefaultValue: true,

--- a/v7/go.mod
+++ b/v7/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/frankban/quicktest v1.11.2
 	github.com/google/go-cmp v0.5.2
-	github.com/sirupsen/logrus v1.4.2
+	github.com/sirupsen/logrus v1.8.1
 )

--- a/v7/go.sum
+++ b/v7/go.sum
@@ -17,10 +17,14 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR contains the following:

### Added
- `Offline` configuration option to indicate whether the SDK is allowed to make HTTP calls or not. In 'offline' mode, the SDK works from the cache only.
- `Hooks` configuration option that allows subscribing to `OnConfigChanged` / `OnFlagEvaluated(EvaluationDetails)` / `OnError(String)` events.
- `GetValueDetails()` / `GetAllValueDetails()` methods to retrieve evaluation details of feature flags/settings. The details include:
  - `Value`: The evaluated feature flag's value.
  - `Key`: The evaluated feature flag's key.
  - `User`: The user used for evaluation.
  - `VariationId`: The diagnostic ID of the targeting, percentage, or default rule the evaluation was based on.
  - `IsDefaultValue`: True when the default value passed to `GetValue()` or `GetValueDetails()` is returned.
  - `Error`: The error when the evaluation fails otherwise, nil.
  - `FetchTime`: The time when the last config was fetched.
  - `MatchedEvaluationRule`: If the evaluation was based on a targeting rule, this field contains that specific rule.
  - `MatchedEvaluationPercentageRule`: If the evaluation was based on a percentage rule, this field contains that specific rule.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
