### PR TITLE
Always log fetch errors / Option to control Refresh with passed Context

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.18.x, 1.20.x, 1.21.x]
+        go: [1.23.x, 1.24.x, 1.25.x]
     
     steps:
     - uses: actions/checkout@v5

--- a/auto_polling_policy_test.go
+++ b/auto_polling_policy_test.go
@@ -12,7 +12,7 @@ import (
 func TestAutoPollingPolicy_PollChange(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
-	srv.setResponse(configResponse{body: `{"test":1}`})
+	srv.setResponse(configResponse{body: `{"f":{}}`})
 
 	cfg := srv.config()
 	cfg.PollInterval = 10 * time.Millisecond
@@ -21,13 +21,13 @@ func TestAutoPollingPolicy_PollChange(t *testing.T) {
 	err := client.Refresh(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
-	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"test":1}`)
+	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"f":{}}`)
 
-	srv.setResponse(configResponse{body: `{"test":2}`})
-	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"test":1}`)
+	srv.setResponse(configResponse{body: `{"p":{},"f":{}}`})
+	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"f":{}}`)
 
 	time.Sleep(40 * time.Millisecond)
-	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"test":2}`)
+	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"p":{},"f":{}}`)
 }
 
 func TestAutoPollingPolicy_FetchFail(t *testing.T) {
@@ -61,28 +61,24 @@ func TestAutoPollingPolicy_DoubleClose(t *testing.T) {
 func TestAutoPollingPolicy_WithNotify(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
-	srv.setResponse(configResponse{body: `{"test":1}`})
+	srv.setResponse(configResponse{body: `{"f":{}}`})
 	cfg := srv.config()
 	notifyc := make(chan struct{})
 	cfg.PollInterval = time.Millisecond
 	cfg.Hooks = &Hooks{OnConfigChanged: func() { notifyc <- struct{}{} }}
 	client := NewCustomClient(cfg)
 	defer client.Close()
-	select {
-	case <-notifyc:
-	case <-time.After(time.Second):
-		t.Fatalf("timed out waiting for notification")
-	}
-	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"test":1}`)
+	WithTimeout(time.Second, func() {
+		<-notifyc
+	})
+	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"f":{}}`)
 
 	// Change the content and we should see another notification.
-	srv.setResponse(configResponse{body: `{"test":2}`})
-	select {
-	case <-notifyc:
-	case <-time.After(time.Second):
-		t.Fatalf("timed out waiting for notification")
-	}
-	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"test":2}`)
+	srv.setResponse(configResponse{body: `{"p":{},"f":{}}`})
+	WithTimeout(time.Second, func() {
+		<-notifyc
+	})
+	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"p":{},"f":{}}`)
 
 	// Check that we don't see any more notifications.
 	select {

--- a/config_fetcher.go
+++ b/config_fetcher.go
@@ -30,7 +30,7 @@ func (f *fetcherError) Error() string {
 
 type fetcher interface {
 	refreshIfOlder(ctx context.Context, before time.Time, wait bool) error
-	refreshIfOlderWithContextPassthrough(ctx context.Context, before time.Time, wait bool) error
+	refreshIfOlderWithContext(ctx context.Context, before time.Time, wait bool) error
 	close()
 	current() *config
 	isOffline() bool
@@ -177,13 +177,13 @@ func (f *configFetcher) refreshIfOlder(ctx context.Context, before time.Time, wa
 	return f.refreshIfOlderWithContexts(ctx, f.ctx, before, wait)
 }
 
-// refreshIfOlderWithContextPassthrough refreshes the configuration if it was retrieved
+// refreshIfOlderWithCancel refreshes the configuration if it was retrieved
 // before the given time or if there is no current configuration. If the context is
 // canceled while the refresh is in progress, it will stop the underlying HTTP request.
 //
 // If wait is false, refreshIfOlder returns immediately without waiting
 // for the refresh to complete.
-func (f *configFetcher) refreshIfOlderWithContextPassthrough(ctx context.Context, before time.Time, wait bool) error {
+func (f *configFetcher) refreshIfOlderWithContext(ctx context.Context, before time.Time, wait bool) error {
 	return f.refreshIfOlderWithContexts(ctx, ctx, before, wait)
 }
 
@@ -478,7 +478,7 @@ func (e *emptyFetcher) refreshIfOlder(_ context.Context, _ time.Time, _ bool) er
 	return errors.New("config fetch failed: SDK Key is invalid")
 }
 
-func (e *emptyFetcher) refreshIfOlderWithContextPassthrough(_ context.Context, _ time.Time, _ bool) error {
+func (e *emptyFetcher) refreshIfOlderWithContext(_ context.Context, _ time.Time, _ bool) error {
 	return errors.New("config fetch failed: SDK Key is invalid")
 }
 

--- a/config_fetcher.go
+++ b/config_fetcher.go
@@ -433,7 +433,7 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 		return nil, nil
 	}
 
-	if response.StatusCode >= 200 && response.StatusCode < 300 {
+	if response.StatusCode == 200 {
 		body, err := io.ReadAll(response.Body)
 		if err != nil {
 			return nil, &fetcherError{EventId: 1103, Err: fmt.Errorf("unexpected error occurred while trying to fetch config JSON; it is most likely due to a local network issue; please make sure your application can reach the ConfigCat CDN servers (or your proxy server) over HTTP: %v", err)}
@@ -441,6 +441,9 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 		config, err := parseConfig(body, response.Header.Get("Etag"), time.Now(), f.logger, f.defaultUser, f.overrides, f.hooks)
 		if err != nil {
 			return nil, &fetcherError{EventId: 1105, Err: fmt.Errorf("fetching config JSON was successful but the HTTP response content was invalid: %v", err)}
+		}
+		if config.root.Settings == nil && config.root.Segments == nil && config.root.Preferences == nil {
+			return nil, &fetcherError{EventId: 1103, Err: fmt.Errorf("invalid config JSON content: %s", body)}
 		}
 		f.logger.Debugf("config fetch succeeded: new config fetched")
 		return config, nil

--- a/config_fetcher.go
+++ b/config_fetcher.go
@@ -30,6 +30,7 @@ func (f *fetcherError) Error() string {
 
 type fetcher interface {
 	refreshIfOlder(ctx context.Context, before time.Time, wait bool) error
+	refreshIfOlderWithContextPassthrough(ctx context.Context, before time.Time, wait bool) error
 	close()
 	current() *config
 	isOffline() bool
@@ -167,12 +168,26 @@ func (f *configFetcher) current() *config {
 
 // refreshIfOlder refreshes the configuration if it was retrieved
 // before the given time or if there is no current configuration. If the context is
-// canceled while the refresh is in progress, Refresh will return but
+// canceled while the refresh is in progress, it will return, but
 // the underlying HTTP request will not be stopped.
 //
 // If wait is false, refreshIfOlder returns immediately without waiting
 // for the refresh to complete.
 func (f *configFetcher) refreshIfOlder(ctx context.Context, before time.Time, wait bool) error {
+	return f.refreshIfOlderWithContexts(ctx, f.ctx, before, wait)
+}
+
+// refreshIfOlderWithContextPassthrough refreshes the configuration if it was retrieved
+// before the given time or if there is no current configuration. If the context is
+// canceled while the refresh is in progress, it will stop the underlying HTTP request.
+//
+// If wait is false, refreshIfOlder returns immediately without waiting
+// for the refresh to complete.
+func (f *configFetcher) refreshIfOlderWithContextPassthrough(ctx context.Context, before time.Time, wait bool) error {
+	return f.refreshIfOlderWithContexts(ctx, ctx, before, wait)
+}
+
+func (f *configFetcher) refreshIfOlderWithContexts(requestCtx context.Context, terminateCtx context.Context, before time.Time, wait bool) error {
 	f.mu.Lock()
 	prevConfig := f.current()
 	if prevConfig != nil && !prevConfig.fetchTime.Before(before) {
@@ -184,7 +199,7 @@ func (f *configFetcher) refreshIfOlder(ctx context.Context, before time.Time, wa
 		fetchDone = make(chan error, 1)
 		f.fetchDone = fetchDone
 		f.wg.Add(1)
-		go f.fetcher(ctx, prevConfig)
+		go f.fetcher(terminateCtx, prevConfig)
 	}
 	f.mu.Unlock()
 	if !wait {
@@ -196,8 +211,8 @@ func (f *configFetcher) refreshIfOlder(ctx context.Context, before time.Time, wa
 		// concurrent refresh calls can have access to it.
 		fetchDone <- err
 		return err
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-requestCtx.Done():
+		return requestCtx.Err()
 	}
 }
 
@@ -223,7 +238,7 @@ func (f *configFetcher) fetcher(ctx context.Context, prevConfig *config) {
 			go f.hooks.OnConfigChanged()
 		}
 	}
-	// Unblock any Client.getValue call that's waiting for the first configuration to be retrieved.
+	// Unblock any Client.getValue call waiting for the first configuration to be retrieved.
 	f.doneGetOnce.Do(func() {
 		close(f.doneInitialGet)
 	})
@@ -401,7 +416,6 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 	if etag != "" {
 		request.Header.Add("If-None-Match", etag)
 	}
-	request = request.WithContext(f.ctx)
 	response, err := f.client.Do(request)
 	if err != nil {
 		if os.IsTimeout(err) {
@@ -461,6 +475,10 @@ func newEmptyFetcher() fetcher {
 }
 
 func (e *emptyFetcher) refreshIfOlder(_ context.Context, _ time.Time, _ bool) error {
+	return errors.New("config fetch failed: SDK Key is invalid")
+}
+
+func (e *emptyFetcher) refreshIfOlderWithContextPassthrough(_ context.Context, _ time.Time, _ bool) error {
 	return errors.New("config fetch failed: SDK Key is invalid")
 }
 

--- a/config_fetcher.go
+++ b/config_fetcher.go
@@ -433,7 +433,7 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 		return nil, nil
 	}
 
-	if response.StatusCode == 200 {
+	if response.StatusCode == http.StatusOK {
 		body, err := io.ReadAll(response.Body)
 		if err != nil {
 			return nil, &fetcherError{EventId: 1103, Err: fmt.Errorf("unexpected error occurred while trying to fetch config JSON; it is most likely due to a local network issue; please make sure your application can reach the ConfigCat CDN servers (or your proxy server) over HTTP: %v", err)}

--- a/config_fetcher.go
+++ b/config_fetcher.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/configcat/go-sdk/v9/configcatcache"
 	"io"
 	"net/http"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/configcat/go-sdk/v9/configcatcache"
 )
 
 const (
@@ -183,7 +184,7 @@ func (f *configFetcher) refreshIfOlder(ctx context.Context, before time.Time, wa
 		fetchDone = make(chan error, 1)
 		f.fetchDone = fetchDone
 		f.wg.Add(1)
-		go f.fetcher(prevConfig)
+		go f.fetcher(ctx, prevConfig)
 	}
 	f.mu.Unlock()
 	if !wait {
@@ -206,23 +207,15 @@ func (f *configFetcher) refreshIfOlder(ctx context.Context, before time.Time, wa
 // Note: although this is started asynchronously, the configFetcher
 // logic guarantees that there's never more than one goroutine
 // at a time running f.fetcher.
-func (f *configFetcher) fetcher(prevConfig *config) {
+func (f *configFetcher) fetcher(ctx context.Context, prevConfig *config) {
 	defer f.wg.Done()
-	config, newURL, err := f.fetchConfig(f.ctx, f.baseURL, prevConfig)
+	config, newURL, err := f.fetchConfig(ctx, f.baseURL, prevConfig)
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if err != nil {
-		var fErr *fetcherError
-		if errors.As(err, &fErr) {
-			f.logger.Errorf(fErr.EventId, "config fetch failed: %v", fErr.Err)
-		} else {
-			f.logger.Errorf(0, "config fetch failed: %v", err)
-		}
-		err = fmt.Errorf("config fetch failed: %v", err)
-	} else if config != nil && !config.equal(prevConfig) {
+	if err == nil && config != nil && !config.equal(prevConfig) {
 		f.baseURL = newURL
 		f.config.Store(config)
-		if err := f.saveToCache(f.ctx, config.fetchTime, config.etag, config.jsonBody); err != nil {
+		if err := f.saveToCache(ctx, config.fetchTime, config.etag, config.jsonBody); err != nil {
 			f.logger.Errorf(2201, "error occurred while writing the cache: %v", err)
 		}
 		contentEquals := config.equalContent(prevConfig)
@@ -260,16 +253,33 @@ func (f *configFetcher) fetchConfig(ctx context.Context, baseURL string, prevCon
 		return cfg, baseURL, nil
 	}
 
+	var etag string
+	if prevConfig != nil {
+		etag = prevConfig.etag
+	}
+
 	// We are online, use HTTP
-	cfg, newBaseURL, err := f.fetchHTTP(ctx, baseURL, prevConfig)
-	if err == nil {
-		return cfg, newBaseURL, nil
-	}
-	cfg = f.readCache(ctx, prevConfig)
+	cfg, newBaseURL, err := f.fetchHTTP(ctx, baseURL, etag)
 	if cfg == nil {
-		return nil, "", err
+		if err != nil {
+			var fErr *fetcherError
+			if errors.As(err, &fErr) {
+				f.logger.Errorf(fErr.EventId, "config fetch failed: %v", fErr.Err)
+			} else {
+				f.logger.Errorf(0, "config fetch failed: %v", err)
+			}
+		}
+		cached := f.readCache(ctx, prevConfig)
+		if cached == nil {
+			if err != nil {
+				return nil, "", fmt.Errorf("config fetch failed: %v", err)
+			}
+			return prevConfig.withFetchTime(time.Now()), baseURL, nil
+		}
+		return cached, baseURL, nil
 	}
-	return cfg, baseURL, nil
+
+	return cfg, newBaseURL, nil
 }
 
 func (f *configFetcher) readCache(ctx context.Context, prevConfig *config) (_ *config) {
@@ -320,12 +330,15 @@ func (f *configFetcher) saveToCache(ctx context.Context, fetchTime time.Time, eT
 //
 // It returns the newly fetched configuration and the new base URL
 // (empty if it hasn't changed).
-func (f *configFetcher) fetchHTTP(ctx context.Context, baseURL string, prevConfig *config) (newConfig *config, newBaseURL string, err error) {
+func (f *configFetcher) fetchHTTP(ctx context.Context, baseURL string, etag string) (newConfig *config, newBaseURL string, err error) {
 	f.logger.Debugf("fetching from %v", baseURL)
 	for i := 0; i < 3; i++ {
-		config, err := f.fetchHTTPWithoutRedirect(ctx, baseURL, prevConfig)
+		config, err := f.fetchHTTPWithoutRedirect(ctx, baseURL, etag)
 		if err != nil {
 			return nil, "", err
+		}
+		if config == nil {
+			return nil, "", nil
 		}
 		preferences := config.root.Preferences
 		if preferences == nil ||
@@ -375,7 +388,7 @@ func (f *configFetcher) fetchHTTP(ctx context.Context, baseURL string, prevConfi
 }
 
 // fetchHTTPWithoutRedirect does the actual HTTP fetch of the config.
-func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL string, prevConfig *config) (*config, error) {
+func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL string, etag string) (*config, error) {
 	if f.sdkKey == "" {
 		return nil, &fetcherError{EventId: 0, Err: fmt.Errorf("empty SDK key in configcat configuration")}
 	}
@@ -385,8 +398,8 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 	}
 	request.Header.Set("X-ConfigCat-UserAgent", "ConfigCat-Go/"+f.pollingIdentifier+"-"+version)
 
-	if prevConfig != nil && prevConfig.etag != "" {
-		request.Header.Add("If-None-Match", prevConfig.etag)
+	if etag != "" {
+		request.Header.Add("If-None-Match", etag)
 	}
 	request = request.WithContext(f.ctx)
 	response, err := f.client.Do(request)
@@ -397,11 +410,13 @@ func (f *configFetcher) fetchHTTPWithoutRedirect(ctx context.Context, baseURL st
 			return nil, &fetcherError{EventId: 1103, Err: fmt.Errorf("unexpected error occurred while trying to fetch config JSON; it is most likely due to a local network issue; please make sure your application can reach the ConfigCat CDN servers (or your proxy server) over HTTP: %v", err)}
 		}
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 
 	if response.StatusCode == 304 {
 		f.logger.Debugf("config fetch succeeded: not modified")
-		return prevConfig.withFetchTime(time.Now()), nil
+		return nil, nil
 	}
 
 	if response.StatusCode >= 200 && response.StatusCode < 300 {

--- a/config_fetcher.go
+++ b/config_fetcher.go
@@ -177,7 +177,7 @@ func (f *configFetcher) refreshIfOlder(ctx context.Context, before time.Time, wa
 	return f.refreshIfOlderWithContexts(ctx, f.ctx, before, wait)
 }
 
-// refreshIfOlderWithCancel refreshes the configuration if it was retrieved
+// refreshIfOlderWithContext refreshes the configuration if it was retrieved
 // before the given time or if there is no current configuration. If the context is
 // canceled while the refresh is in progress, it will stop the underlying HTTP request.
 //

--- a/config_parser.go
+++ b/config_parser.go
@@ -113,6 +113,9 @@ func (c *config) equalContent(c1 *config) bool {
 }
 
 func (c *config) withFetchTime(t time.Time) *config {
+	if c == nil {
+		return nil
+	}
 	c1 := *c
 	c1.fetchTime = t
 	return &c1

--- a/configcat_client.go
+++ b/configcat_client.go
@@ -225,11 +225,11 @@ func (client *Client) RefreshIfOlder(ctx context.Context, age time.Duration) err
 	return client.fetcher.refreshIfOlder(ctx, time.Now().Add(-age), true)
 }
 
-// RefreshWithContextPassthrough is like Refresh, but the given context is passed all the way down
+// RefreshWithContext is like Refresh, but the given context is passed all the way down
 // to the refresh operation, so whenever the context is canceled while the refresh is in progress,
 // the underlying HTTP request will also be stopped.
-func (client *Client) RefreshWithContextPassthrough(ctx context.Context) error {
-	return client.fetcher.refreshIfOlderWithContextPassthrough(ctx, time.Now().Add(1), true)
+func (client *Client) RefreshWithContext(ctx context.Context) error {
+	return client.fetcher.refreshIfOlderWithContext(ctx, time.Now().Add(1), true)
 }
 
 // SetOffline configures the SDK to not initiate HTTP requests.

--- a/configcat_client.go
+++ b/configcat_client.go
@@ -215,8 +215,7 @@ func (client *Client) Refresh(ctx context.Context) error {
 }
 
 // RefreshIfOlder is like Refresh but refreshes the configuration only
-// if the most recently fetched configuration is older than the given
-// age.
+// if the most recently fetched configuration is older than the given age.
 func (client *Client) RefreshIfOlder(ctx context.Context, age time.Duration) error {
 	if client.fetcher.isOffline() {
 		var message = "client is in offline mode, it cannot initiate HTTP calls"
@@ -224,6 +223,13 @@ func (client *Client) RefreshIfOlder(ctx context.Context, age time.Duration) err
 		return fmt.Errorf(message)
 	}
 	return client.fetcher.refreshIfOlder(ctx, time.Now().Add(-age), true)
+}
+
+// RefreshWithContextPassthrough is like Refresh, but the given context is passed all the way down
+// to the refresh operation, so whenever the context is canceled while the refresh is in progress,
+// the underlying HTTP request will also be stopped.
+func (client *Client) RefreshWithContextPassthrough(ctx context.Context) error {
+	return client.fetcher.refreshIfOlderWithContextPassthrough(ctx, time.Now().Add(1), true)
 }
 
 // SetOffline configures the SDK to not initiate HTTP requests.

--- a/configcat_client_test.go
+++ b/configcat_client_test.go
@@ -137,7 +137,7 @@ func TestClient_Refresh_Cancel_Will_Stop_Fetch(t *testing.T) {
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	_ = client.RefreshWithContextPassthrough(ctx)
+	_ = client.RefreshWithContext(ctx)
 	duration := time.Since(start)
 	c.Assert(duration < 20*time.Millisecond, qt.IsTrue)
 

--- a/configcat_client_test.go
+++ b/configcat_client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,13 +37,13 @@ func TestClient_Refresh(t *testing.T) {
 	defer client.Close()
 
 	srv.setResponseJSON(rootNodeWithKeyValue("key", "value"))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 
 	c.Assert(result, qt.Equals, "value")
 
 	srv.setResponseJSON(rootNodeWithKeyValue("key", "value2"))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result = client.GetStringValue("key", "default", nil)
 	if result != "value2" {
 		t.Error("Expecting non default string value")
@@ -58,7 +59,7 @@ func TestClient_Refresh_Canceled(t *testing.T) {
 	defer client.Close()
 
 	srv.setResponseJSON(rootNodeWithKeyValue("key", "value"))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "value")
 
@@ -69,7 +70,7 @@ func TestClient_Refresh_Canceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	t0 := time.Now()
-	client.Refresh(ctx)
+	_ = client.Refresh(ctx)
 	if d := time.Since(t0); d < 10*time.Millisecond || d > 50*time.Millisecond {
 		t.Errorf("refresh returned too quickly; got %v want >10ms, <50ms", d)
 	}
@@ -90,16 +91,64 @@ func TestClient_Refresh_Timeout(t *testing.T) {
 		body:  marshalJSON(rootNodeWithKeyValue("key", "value")),
 		sleep: 20 * time.Millisecond,
 	})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "default")
+}
+
+func TestClient_Refresh_Cancel_Wont_Stop_Fetch(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	cfg := srv.config()
+	cfg.PollingMode = Manual
+	cfg.LogLevel = LogLevelNone
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	srv.setResponse(configResponse{
+		body:  marshalJSON(rootNodeWithKeyValue("key", "value")),
+		sleep: 20 * time.Millisecond,
+	})
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_ = client.Refresh(ctx)
+	duration := time.Since(start)
+	c.Assert(duration < 20*time.Millisecond, qt.IsTrue)
+
+	WaitUntil(time.Second, func() bool {
+		result := client.GetStringValue("key", "default", nil)
+		return result == "value"
+	})
+}
+
+func TestClient_Refresh_Cancel_Will_Stop_Fetch(t *testing.T) {
+	c := qt.New(t)
+	srv := newConfigServer(t)
+	cfg := srv.config()
+	cfg.PollingMode = Manual
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	srv.setResponse(configResponse{
+		body:  marshalJSON(rootNodeWithKeyValue("key", "value")),
+		sleep: 5 * time.Second,
+	})
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_ = client.RefreshWithContextPassthrough(ctx)
+	duration := time.Since(start)
+	c.Assert(duration < 20*time.Millisecond, qt.IsTrue)
+
+	c.Assert(srv.allResponses(), qt.HasLen, 0)
 }
 
 func TestClient_Float(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(rootNodeWithKeyValue("key", 3213.0))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetFloatValue("key", 0, nil)
 	c.Assert(result, qt.Equals, 3213.0)
 }
@@ -112,7 +161,7 @@ func TestClient_KeyNotFound(t *testing.T) {
 	Bool("k1", false)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(rootNodeWithKeyValue("k2", 3213))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetIntValue("k1", 0, nil)
 	c.Assert(result, qt.Equals, 0)
 }
@@ -141,7 +190,7 @@ func TestClient_Get_IsOneOf_Does_Not_Use_Contains_Semantics(t *testing.T) {
 			},
 		},
 	})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	matchingUser := &UserData{Identifier: "mple"}
 	result := client.GetBoolValue("feature", false, matchingUser)
@@ -171,7 +220,7 @@ func TestClient_Get_Latest(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(rootNodeWithKeyValue("key", 3213.0))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	result := client.GetFloatValue("key", 0, nil)
 	c.Assert(result, qt.Equals, 3213.0)
@@ -194,7 +243,7 @@ func TestClient_Get_WithFailingCacheSet(t *testing.T) {
 	defer client.Close()
 
 	srv.setResponseJSON(rootNodeWithKeyValue("key", 3213.0))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetFloatValue("key", 0, nil)
 	c.Assert(result, qt.Equals, 3213.0)
 }
@@ -211,7 +260,7 @@ func TestClient_Get_WithEmptyKey(t *testing.T) {
 	srv := newConfigServer(t)
 	srv.setResponseJSON(variationConfig)
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	c.Assert(client.GetBoolValue("", false, nil), qt.Equals, false)
 }
 
@@ -222,7 +271,7 @@ func TestClient_Keys(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	keys := client.GetAllKeys()
 	c.Assert(keys, qt.HasLen, 16)
@@ -235,7 +284,7 @@ func TestClient_AllValues(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	keys := client.GetAllValues(nil)
 	c.Assert(keys, qt.HasLen, 16)
@@ -245,7 +294,7 @@ func TestClient_VariationID(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(variationConfig)
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetBoolValueDetails("first", false, nil)
 	c.Assert(result.Data.VariationID, qt.Equals, "fakeIDFirst")
 }
@@ -254,7 +303,7 @@ func TestClient_VariationID_Default(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(variationConfig)
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetBoolValueDetails("nonexisting", false, nil)
 	c.Assert(result.Data.VariationID, qt.Equals, "")
 }
@@ -263,7 +312,7 @@ func TestClient_GetAllVariationIDs(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(variationConfig)
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetAllValueDetails(nil)
 	c.Assert(result, qt.HasLen, 2)
 }
@@ -272,7 +321,7 @@ func TestClient_VariationIDs_Empty(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponse(configResponse{body: `{ "f": {} }`})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetAllValueDetails(nil)
 	c.Assert(result, qt.HasLen, 0)
 }
@@ -281,7 +330,7 @@ func TestClient_GetKeyAndValue(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(variationConfig)
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	key, value := client.GetKeyValueForVariationID("fakeIDSecond")
 	c.Assert(key, qt.Equals, "second")
 	c.Assert(value, qt.Equals, true)
@@ -291,7 +340,7 @@ func TestClient_GetKeyAndValue_Empty(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(variationConfig)
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	key, value := client.GetKeyValueForVariationID("nonexisting")
 	c.Assert(key, qt.Equals, "")
 	c.Assert(value, qt.Equals, nil)
@@ -310,14 +359,14 @@ func TestClient_GetWithRedirectSuccess(t *testing.T) {
 		},
 	})
 	srv2.setResponseJSON(rootNodeWithKeyValue("key", "value"))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "value")
 	c.Assert(srv1.allResponses(), qt.HasLen, 1)
 	c.Assert(srv2.allResponses(), qt.HasLen, 1)
 
 	// Another request should go direct to the second server.
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	c.Assert(srv1.allResponses(), qt.HasLen, 1)
 	c.Assert(srv2.allResponses(), qt.HasLen, 2)
 }
@@ -341,7 +390,7 @@ func TestClient_GetWithDifferentURLAndNoRedirect(t *testing.T) {
 		},
 	})
 	srv2.setResponseJSON(rootNodeWithKeyValue("key", "value2"))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	// Check that the value still comes from the same server and
 	// that no requests were made to the second server.
@@ -370,7 +419,7 @@ func TestClient_GetWithRedirectToSameURL(t *testing.T) {
 		},
 	})
 	srv2.setResponseJSON(rootNodeWithKeyValue("key", "value2"))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "value1")
 
@@ -421,7 +470,7 @@ func TestClient_GetWithStandardURLAndShouldRedirect(t *testing.T) {
 		LogLevel:  LogLevelDebug,
 		Transport: transport,
 	})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "value")
 	c.Assert(transport.requests, qt.HasLen, 2)
@@ -453,13 +502,13 @@ func TestClient_GetWithStandardURLAndNoRedirect(t *testing.T) {
 		LogLevel:  LogLevelDebug,
 		Transport: transport,
 	})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "value1")
 
 	transport.enqueue(200, marshalJSON(rootNodeWithKeyValue("key", "value2")))
 	// The next request should go to the redirected server.
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	result = client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "value2")
@@ -487,7 +536,7 @@ func TestClient_GetWithRedirectLoop(t *testing.T) {
 			Redirect: &redirect,
 		},
 	})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "default")
@@ -499,7 +548,7 @@ func TestClient_GetWithInvalidConfig(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponse(configResponse{body: "invalid-json"})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValue("key", "default", nil)
 	c.Assert(result, qt.Equals, "default")
 }
@@ -508,7 +557,7 @@ func TestClient_GetDetails_WithInvalidConfig(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponse(configResponse{body: "invalid-json"})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	result := client.GetStringValueDetails("key", "default", nil)
 	_, ok := result.Data.Error.(ErrConfigJsonMissing)
 	c.Assert(ok, qt.IsTrue)
@@ -520,7 +569,7 @@ func TestClient_GetInt(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(rootNodeWithKeyValue("key", 99))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	c.Check(client.GetIntValue("key", 0, nil), qt.Equals, 99)
 }
 
@@ -559,7 +608,7 @@ func TestClient_DefaultUser(t *testing.T) {
 			},
 		},
 	})
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	c.Check(client.GetStringValue("foo", "", nil), qt.Equals, "somewhere-match")
 
 	snap := client.Snapshot(nil)
@@ -582,13 +631,13 @@ func TestSnapshot_Get(t *testing.T) {
 	c := qt.New(t)
 	srv, client := getTestClients(t)
 	srv.setResponseJSON(rootNodeWithKeyValue("key", 99))
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	snap := client.Snapshot(nil)
 	c.Check(snap.GetValue("key"), qt.Equals, 99)
 	c.Check(snap.FetchTime(), qt.Not(qt.Equals), time.Time{})
 	srv.setResponseJSON(rootNodeWithKeyValue("key", 101))
 	time.Sleep(1 * time.Millisecond) // wait a bit to ensure fetch times don't collide
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 	c.Check(snap.GetValue("key"), qt.Equals, 99)
 	c.Check(client.Snapshot(nil).GetValue("key"), qt.Equals, 101)
 	c.Check(client.Snapshot(nil).FetchTime().After(snap.FetchTime()), qt.IsTrue)
@@ -601,7 +650,7 @@ func TestClient_GetBoolDetails(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
 
@@ -625,7 +674,7 @@ func TestClient_GetStringDetails(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
 
@@ -649,7 +698,7 @@ func TestClient_GetIntDetails(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	user := &UserData{Identifier: "a@configcat.com"}
 
@@ -670,7 +719,7 @@ func TestClient_GetFloatDetails(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
 
@@ -694,7 +743,7 @@ func TestClient_GetAllDetails(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	user := &UserData{Identifier: "a@configcat.com", Email: "a@configcat.com"}
 
@@ -710,10 +759,11 @@ func TestClient_GetBoolDetails_NotExist(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetBoolValueDetails("non-existent", false, nil)
-	_, ok := details.Data.Error.(ErrKeyNotFound)
+	var errKeyNotFound ErrKeyNotFound
+	ok := errors.As(details.Data.Error, &errKeyNotFound)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.IsFalse)
 }
@@ -725,10 +775,11 @@ func TestClient_GetStringDetails_NotExist(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetStringValueDetails("non-existent", "", nil)
-	_, ok := details.Data.Error.(ErrKeyNotFound)
+	var errKeyNotFound ErrKeyNotFound
+	ok := errors.As(details.Data.Error, &errKeyNotFound)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.Equals, "")
 }
@@ -740,10 +791,11 @@ func TestClient_GetIntDetails_NotExist(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetIntValueDetails("non-existent", 0, nil)
-	_, ok := details.Data.Error.(ErrKeyNotFound)
+	var errKeyNotFound ErrKeyNotFound
+	ok := errors.As(details.Data.Error, &errKeyNotFound)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.Equals, 0)
 }
@@ -755,10 +807,11 @@ func TestClient_GetFloatDetails_NotExist(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetFloatValueDetails("non-existent", 0, nil)
-	_, ok := details.Data.Error.(ErrKeyNotFound)
+	var errKeyNotFound ErrKeyNotFound
+	ok := errors.As(details.Data.Error, &errKeyNotFound)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.Equals, float64(0))
 }
@@ -770,10 +823,11 @@ func TestClient_GetBoolDetails_TypeMismatch(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetBoolValueDetails("integerDefaultOne", false, nil)
-	err, ok := details.Data.Error.(ErrSettingTypeMismatch)
+	var err ErrSettingTypeMismatch
+	ok := errors.As(details.Data.Error, &err)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.IsFalse)
 	c.Assert(err.Error(), qt.Equals, "the type of the setting 'integerDefaultOne' doesn't match with the expected type; setting's type was 'int' but the expected type was 'bool'")
@@ -786,10 +840,11 @@ func TestClient_GetStringDetails_TypeMismatch(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetStringValueDetails("integerDefaultOne", "", nil)
-	err, ok := details.Data.Error.(ErrSettingTypeMismatch)
+	var err ErrSettingTypeMismatch
+	ok := errors.As(details.Data.Error, &err)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.Equals, "")
 	c.Assert(err.Error(), qt.Equals, "the type of the setting 'integerDefaultOne' doesn't match with the expected type; setting's type was 'int' but the expected type was 'string'")
@@ -802,10 +857,11 @@ func TestClient_GetIntDetails_TypeMismatch(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetIntValueDetails("boolDefaultTrue", 0, nil)
-	err, ok := details.Data.Error.(ErrSettingTypeMismatch)
+	var err ErrSettingTypeMismatch
+	ok := errors.As(details.Data.Error, &err)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.Equals, 0)
 	c.Assert(err.Error(), qt.Equals, "the type of the setting 'boolDefaultTrue' doesn't match with the expected type; setting's type was 'bool' but the expected type was 'int'")
@@ -818,10 +874,11 @@ func TestClient_GetFloatDetails_TypeMismatch(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	details := client.GetFloatValueDetails("boolDefaultTrue", 0, nil)
-	err, ok := details.Data.Error.(ErrSettingTypeMismatch)
+	var err ErrSettingTypeMismatch
+	ok := errors.As(details.Data.Error, &err)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(details.Value, qt.Equals, float64(0))
 	c.Assert(err.Error(), qt.Equals, "the type of the setting 'boolDefaultTrue' doesn't match with the expected type; setting's type was 'bool' but the expected type was 'float'")
@@ -834,7 +891,7 @@ func TestClient_GetDetails_Reflected_User(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	user := &struct{ attr string }{"a"}
 
@@ -868,15 +925,13 @@ func TestClient_Hooks_OnFlagEvaluated(t *testing.T) {
 		called <- struct{}{}
 	}}
 	client := NewCustomClient(cfg)
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	_ = client.GetFloatValue("double25Pi25E25Gr25Zero", 0.0, user)
 
-	select {
-	case <-called:
-	case <-time.After(time.Second):
-		t.Fatalf("timed out")
-	}
+	WithTimeout(time.Second, func() {
+		<-called
+	})
 }
 
 func TestClient_Ready_Signal(t *testing.T) {
@@ -891,11 +946,9 @@ func TestClient_Ready_Signal(t *testing.T) {
 	cfg := srv.config()
 	client := NewCustomClient(cfg)
 
-	select {
-	case <-client.Ready():
-	case <-time.After(time.Second):
-		t.Fatalf("timed out")
-	}
+	WithTimeout(time.Second, func() {
+		<-client.Ready()
+	})
 
 	val := client.GetFloatValue("double25Pi25E25Gr25Zero", 0.0, user)
 	c.Assert(val, qt.Equals, 5.561)
@@ -914,11 +967,9 @@ func TestClient_Ready_Signal_NoWait(t *testing.T) {
 	cfg.NoWaitForRefresh = true
 	client := NewCustomClient(cfg)
 
-	select {
-	case <-client.Ready():
-	case <-time.After(time.Second):
-		t.Fatalf("timed out")
-	}
+	WithTimeout(time.Second, func() {
+		<-client.Ready()
+	})
 
 	val := client.GetFloatValue("double25Pi25E25Gr25Zero", 0.0, user)
 	c.Assert(val, qt.Equals, 5.561)
@@ -937,16 +988,14 @@ func TestClient_Ready_Signal_Manual(t *testing.T) {
 	cfg.PollingMode = Manual
 	client := NewCustomClient(cfg)
 
-	select {
-	case <-client.Ready():
-	case <-time.After(time.Second):
-		t.Fatalf("timed out")
-	}
+	WithTimeout(time.Second, func() {
+		<-client.Ready()
+	})
 
 	val := client.GetFloatValue("double25Pi25E25Gr25Zero", 0.0, user)
 	c.Assert(val, qt.Equals, 0.0)
 
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	val = client.GetFloatValue("double25Pi25E25Gr25Zero", 0.0, user)
 	c.Assert(val, qt.Equals, 5.561)
@@ -965,11 +1014,9 @@ func TestClient_Ready_Signal_Lazy(t *testing.T) {
 	cfg.PollingMode = Lazy
 	client := NewCustomClient(cfg)
 
-	select {
-	case <-client.Ready():
-	case <-time.After(time.Second):
-		t.Fatalf("timed out")
-	}
+	WithTimeout(time.Second, func() {
+		<-client.Ready()
+	})
 
 	val := client.GetFloatValue("double25Pi25E25Gr25Zero", 0.0, user)
 	c.Assert(val, qt.Equals, 5.561)
@@ -984,18 +1031,18 @@ func TestClient_InitOffline(t *testing.T) {
 	config := srv.config()
 	config.Offline = true
 	client := NewCustomClient(config)
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	c.Assert(client.IsOffline(), qt.IsTrue)
 
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	c.Assert(srv.requestCount, qt.Equals, 0)
 
 	client.SetOnline()
 	c.Assert(client.IsOffline(), qt.IsFalse)
 
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	c.Assert(srv.requestCount, qt.Equals, 1)
 }
@@ -1007,7 +1054,7 @@ func TestClient_OfflineOnlineMode(t *testing.T) {
 		body: contentForIntegrationTestKey("PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"),
 	})
 	client := NewCustomClient(srv.config())
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	c.Assert(srv.requestCount, qt.Equals, 1)
 	c.Assert(client.IsOffline(), qt.IsFalse)
@@ -1015,14 +1062,14 @@ func TestClient_OfflineOnlineMode(t *testing.T) {
 	client.SetOffline()
 	c.Assert(client.IsOffline(), qt.IsTrue)
 
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	c.Assert(srv.requestCount, qt.Equals, 1)
 
 	client.SetOnline()
 	c.Assert(client.IsOffline(), qt.IsFalse)
 
-	client.Refresh(context.Background())
+	_ = client.Refresh(context.Background())
 
 	c.Assert(srv.requestCount, qt.Equals, 2)
 }
@@ -1160,4 +1207,38 @@ func (m *mockHTTPTransport) enqueue(statusCode int, body string) {
 		StatusCode: statusCode,
 		Body:       ioutil.NopCloser(strings.NewReader(body)),
 	})
+}
+
+func WaitUntil(timeout time.Duration, f func() bool) {
+	t := time.After(timeout)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		for {
+			select {
+			case <-t:
+				panic("timeout expired")
+			default:
+				if f() {
+					wg.Done()
+					return
+				}
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+func WithTimeout(timeout time.Duration, f func()) {
+	t := time.After(timeout)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-t:
+			panic("timeout expired")
+		case <-done:
+		}
+	}()
+	f()
+	done <- struct{}{}
 }

--- a/configcatcache/cacheutils.go
+++ b/configcatcache/cacheutils.go
@@ -42,7 +42,9 @@ func CacheSegmentsFromBytes(cacheBytes []byte) (fetchTime time.Time, eTag string
 
 // CacheSegmentsToBytes serializes the input parameters to a specific format used for caching by the SDK.
 func CacheSegmentsToBytes(fetchTime time.Time, eTag string, config []byte) []byte {
-	toCache := []byte(strconv.FormatInt(fetchTime.UnixMilli(), 10))
+	timeStr := strconv.FormatInt(fetchTime.UnixMilli(), 10)
+	toCache := make([]byte, 0, len(timeStr)+len(eTag)+len(config)+2)
+	toCache = append(toCache, timeStr...)
 	toCache = append(toCache, newLineByte)
 	toCache = append(toCache, eTag...)
 	toCache = append(toCache, newLineByte)

--- a/configcatcache/cacheutils_test.go
+++ b/configcatcache/cacheutils_test.go
@@ -1,0 +1,25 @@
+package configcatcache
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func Test_Cache_Utils(t *testing.T) {
+	c := qt.New(t)
+	cacheEntry := `1686756435844
+test-etag
+{"p":{"u":"https://cdn-global.configcat.com","r":0,"s":"FUkC6RADjzF0vXrDSfJn7BcEBag9afw1Y6jkqjMP9BA="},"f":{"testKey":{"t":1,"v":{"s":"testValue"}}}}`
+
+	ft, etag, configJson, err := CacheSegmentsFromBytes([]byte(cacheEntry))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ft.UnixMilli(), qt.Equals, int64(1686756435844))
+	c.Assert(etag, qt.Equals, "test-etag")
+	c.Assert(string(configJson), qt.Equals, `{"p":{"u":"https://cdn-global.configcat.com","r":0,"s":"FUkC6RADjzF0vXrDSfJn7BcEBag9afw1Y6jkqjMP9BA="},"f":{"testKey":{"t":1,"v":{"s":"testValue"}}}}`)
+
+	tn, _ := time.Parse(time.RFC3339Nano, "2023-06-14T15:27:15.8440000Z")
+	serialized := CacheSegmentsToBytes(tn, "test-etag", []byte(`{"p":{"u":"https://cdn-global.configcat.com","r":0,"s":"FUkC6RADjzF0vXrDSfJn7BcEBag9afw1Y6jkqjMP9BA="},"f":{"testKey":{"t":1,"v":{"s":"testValue"}}}}`))
+	c.Assert(string(serialized), qt.Equals, cacheEntry)
+}

--- a/configserver_test.go
+++ b/configserver_test.go
@@ -5,13 +5,14 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/configcat/go-sdk/v9/configcatcache"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/configcat/go-sdk/v9/configcatcache"
 )
 
 type configServer struct {
@@ -106,7 +107,12 @@ func (srv *configServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	resp := *resp0
-	time.Sleep(resp.sleep)
+	if resp.sleep > 0 {
+		select {
+		case <-req.Context().Done():
+		case <-time.After(resp.sleep):
+		}
+	}
 	if resp.status == 0 {
 		w.Header().Set("Etag", etagOf(resp.body))
 		if req.Header.Get("If-None-Match") == etagOf(resp.body) {
@@ -119,7 +125,9 @@ func (srv *configServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(resp.status)
 	w.Write([]byte(resp.body))
 	// Record the response so that it's possible to check what went on behind the scenes later.
-	srv.responses = append(srv.responses, resp)
+	if req.Context().Err() == nil { // request was not canceled
+		srv.responses = append(srv.responses, resp)
+	}
 }
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,15 @@
 module github.com/configcat/go-sdk/v9
 
-go 1.18
+go 1.23
 
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/frankban/quicktest v1.14.6
-	github.com/google/go-cmp v0.6.0
+	github.com/google/go-cmp v0.7.0
 )
 
 require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -14,3 +16,5 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=

--- a/lazy_loading_policy_test.go
+++ b/lazy_loading_policy_test.go
@@ -85,7 +85,7 @@ func TestLazyLoadingPolicy_NotModified(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
 	srv.setResponse(configResponse{
-		body:  `{"test":1}`,
+		body:  `{"f":{}}`,
 		sleep: time.Millisecond,
 	})
 
@@ -95,14 +95,14 @@ func TestLazyLoadingPolicy_NotModified(t *testing.T) {
 	client := NewCustomClient(cfg)
 	defer client.Close()
 
-	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"test":1}`)
+	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"f":{}}`)
 	time.Sleep(20 * time.Millisecond)
 
-	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"test":1}`)
+	c.Assert(string(client.Snapshot(nil).config.jsonBody), qt.Equals, `{"f":{}}`)
 
 	c.Assert(srv.allResponses(), deepEquals, []configResponse{{
 		status: http.StatusOK,
-		body:   `{"test":1}`,
+		body:   `{"f":{}}`,
 		sleep:  time.Millisecond,
 	}, {
 		status: http.StatusNotModified,

--- a/manual_polling_policy_test.go
+++ b/manual_polling_policy_test.go
@@ -21,14 +21,14 @@ func TestManualPollingPolicy_Refresh(t *testing.T) {
 
 	c.Assert(client.fetcher.current(), qt.IsNil)
 
-	srv.setResponse(configResponse{body: `{"test":1}`})
+	srv.setResponse(configResponse{body: `{"f":{}}`})
 	client.Refresh(context.Background())
-	c.Assert(client.fetcher.current().body(), qt.Equals, `{"test":1}`)
+	c.Assert(client.fetcher.current().body(), qt.Equals, `{"f":{}}`)
 
-	srv.setResponse(configResponse{body: `{"test":2}`})
-	c.Assert(client.fetcher.current().body(), qt.Equals, `{"test":1}`)
+	srv.setResponse(configResponse{body: `{"p":{},"f":{}}`})
+	c.Assert(client.fetcher.current().body(), qt.Equals, `{"f":{}}`)
 	client.Refresh(context.Background())
-	srv.setResponse(configResponse{body: `{"test":2}`})
+	srv.setResponse(configResponse{body: `{"p":{},"f":{}}`})
 }
 
 func TestManualPollingPolicy_FetchFail(t *testing.T) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -3,11 +3,12 @@ package configcat
 import (
 	"context"
 	"fmt"
-	"github.com/configcat/go-sdk/v9/configcatcache"
 	"net/http"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/configcat/go-sdk/v9/configcatcache"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -122,6 +123,32 @@ test-etag
 	tn, _ := time.Parse(time.RFC3339Nano, "2023-06-14T15:27:15.8440000Z")
 	serialized := configcatcache.CacheSegmentsToBytes(tn, "test-etag", []byte(`{"p":{"u":"https://cdn-global.configcat.com","r":0,"s":"FUkC6RADjzF0vXrDSfJn7BcEBag9afw1Y6jkqjMP9BA="},"f":{"testKey":{"t":1,"v":{"s":"testValue"}}}}`))
 	c.Assert(string(serialized), qt.Equals, cacheEntry)
+}
+
+func Test_Ensure_Fetch_Fail_Logger(t *testing.T) {
+	c := qt.New(t)
+	cacheEntry := `1686756435844
+test-etag
+{"p":{"u":"https://cdn-global.configcat.com","r":0,"s":"FUkC6RADjzF0vXrDSfJn7BcEBag9afw1Y6jkqjMP9BA="},"f":{"testKey":{"t":1,"v":{"s":"testValue"}}}}`
+	srv := newConfigServer(t)
+	srv.setResponse(configResponse{
+		status: http.StatusInternalServerError,
+		body:   `something failed`,
+	})
+	logger := newTestLogger(t).(*testLogger)
+	cfg := srv.config()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.Logger = logger
+
+	cache := &simpleCache{entry: []byte(cacheEntry)}
+	cfg.Cache = cache
+
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	val := client.GetStringValue("testKey", "", nil)
+	c.Assert(val, qt.Equals, "testValue")
+	c.Assert(logger.Logs(), qt.Contains, "ERROR: [1101] config fetch failed: unexpected HTTP response was received while trying to fetch config JSON: 500 Internal Server Error")
 }
 
 type simpleCache struct {

--- a/policy_test.go
+++ b/policy_test.go
@@ -181,8 +181,8 @@ test-etag
 				body:   test.b,
 			})
 
-			_ = client.Refresh(t.Context())
-			r, _ := cache.Get(t.Context(), "")
+			_ = client.Refresh(context.Background())
+			r, _ := cache.Get(context.Background(), "")
 			c.Assert(string(r), qt.Equals, cacheEntry)
 		})
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -18,7 +18,7 @@ import (
 func TestFetchFailWithCacheFallback(t *testing.T) {
 	c := qt.New(t)
 	srv := newConfigServer(t)
-	srv.setResponse(configResponse{body: `{"test":1}`})
+	srv.setResponse(configResponse{body: `{"f":{}}`})
 
 	// First use a client to populate the cache.
 	cfg := srv.config()
@@ -31,12 +31,12 @@ func TestFetchFailWithCacheFallback(t *testing.T) {
 
 	client := NewCustomClient(cfg)
 	defer client.Close()
-	client.Refresh(context.Background())
-	c.Assert(client.fetcher.current().body(), qt.Equals, `{"test":1}`)
+	_ = client.Refresh(context.Background())
+	c.Assert(client.fetcher.current().body(), qt.Equals, `{"f":{}}`)
 	for key := range cache.allItems() {
 		cached, _ := cache.Get(context.Background(), key)
 		_, _, b, _ := configcatcache.CacheSegmentsFromBytes(cached)
-		c.Assert(string(b), qt.Equals, `{"test":1}`)
+		c.Assert(string(b), qt.Equals, `{"f":{}}`)
 	}
 
 	// Check that the cache has been populated.
@@ -55,11 +55,11 @@ func TestFetchFailWithCacheFallback(t *testing.T) {
 	client = NewCustomClient(cfg)
 	client.Refresh(context.Background())
 	defer client.Close()
-	c.Assert(client.fetcher.current().body(), qt.Equals, `{"test":1}`)
+	c.Assert(client.fetcher.current().body(), qt.Equals, `{"f":{}}`)
 	for key := range cache.allItems() {
 		cached, _ := cache.Get(context.Background(), key)
 		_, _, b, _ := configcatcache.CacheSegmentsFromBytes(cached)
-		c.Assert(string(b), qt.Equals, `{"test":1}`)
+		c.Assert(string(b), qt.Equals, `{"f":{}}`)
 	}
 
 	time.Sleep(20 * time.Millisecond)
@@ -67,29 +67,29 @@ func TestFetchFailWithCacheFallback(t *testing.T) {
 	// value even when the cache fails subsequently.
 	cache.setGetError(fmt.Errorf("cache failure"))
 	time.Sleep(60 * time.Millisecond)
-	c.Assert(client.fetcher.current().body(), qt.Equals, `{"test":1}`)
+	c.Assert(client.fetcher.current().body(), qt.Equals, `{"f":{}}`)
 
 	// Check that if the cache value changes, it's still consulted.
 	cache.setGetError(nil)
 	for key := range cache.allItems() {
-		cache.Set(context.Background(), key, configcatcache.CacheSegmentsToBytes(time.Now(), "etag", []byte(`{"test":2}`)))
+		cache.Set(context.Background(), key, configcatcache.CacheSegmentsToBytes(time.Now(), "etag", []byte(`{"p":{},"f":{}}`)))
 	}
 	time.Sleep(20 * time.Millisecond)
-	c.Assert(client.fetcher.current().body(), qt.Equals, `{"test":2}`)
+	c.Assert(client.fetcher.current().body(), qt.Equals, `{"p":{},"f":{}}`)
 	for key := range cache.allItems() {
 		cached, _ := cache.Get(context.Background(), key)
 		_, _, b, _ := configcatcache.CacheSegmentsFromBytes(cached)
-		c.Assert(string(b), qt.Equals, `{"test":2}`)
+		c.Assert(string(b), qt.Equals, `{"p":{},"f":{}}`)
 	}
 
 	// Check that we still get the value from the server when it recovers.
-	srv.setResponse(configResponse{body: `{"test":99}`})
+	srv.setResponse(configResponse{body: `{"p":{},"f":{},"s":[]}`})
 	time.Sleep(20 * time.Millisecond)
-	c.Assert(client.fetcher.current().body(), qt.Equals, `{"test":99}`)
+	c.Assert(client.fetcher.current().body(), qt.Equals, `{"p":{},"f":{},"s":[]}`)
 	for key := range cache.allItems() {
 		cached, _ := cache.Get(context.Background(), key)
 		_, _, b, _ := configcatcache.CacheSegmentsFromBytes(cached)
-		c.Assert(string(b), qt.Equals, `{"test":99}`)
+		c.Assert(string(b), qt.Equals, `{"p":{},"f":{},"s":[]}`)
 	}
 }
 
@@ -149,6 +149,43 @@ test-etag
 	val := client.GetStringValue("testKey", "", nil)
 	c.Assert(val, qt.Equals, "testValue")
 	c.Assert(logger.Logs(), qt.Contains, "ERROR: [1101] config fetch failed: unexpected HTTP response was received while trying to fetch config JSON: 500 Internal Server Error")
+}
+
+func Test_Ensure_Empty_Response_Is_Not_Cached(t *testing.T) {
+	c := qt.New(t)
+	cacheEntry := `1686756435844
+test-etag
+{"p":{"u":"https://cdn-global.configcat.com","r":0,"s":"FUkC6RADjzF0vXrDSfJn7BcEBag9afw1Y6jkqjMP9BA="},"f":{"testKey":{"t":1,"v":{"s":"testValue"}}}}`
+	srv := newConfigServer(t)
+	cfg := srv.config()
+	cfg.PollingMode = Manual
+
+	cache := &simpleCache{entry: []byte(cacheEntry)}
+	cfg.Cache = cache
+
+	client := NewCustomClient(cfg)
+	defer client.Close()
+
+	tests := []struct {
+		b string
+	}{
+		{b: "null"},
+		{b: "{}"},
+		{b: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.b, func(t *testing.T) {
+			srv.setResponse(configResponse{
+				status: http.StatusOK,
+				body:   test.b,
+			})
+
+			_ = client.Refresh(t.Context())
+			r, _ := cache.Get(t.Context(), "")
+			c.Assert(string(r), qt.Equals, cacheEntry)
+		})
+	}
 }
 
 type simpleCache struct {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package configcat
 
-const version = "9.0.7"
+const version = "9.1.0"


### PR DESCRIPTION
### Describe the purpose of your pull request
This PR contains the following:
- Increases Go version to `v1.23`
- Fixes a case where fetch errors were not logged. Upon a failed fetch, when there was a valid config JSON in the cache, the fetch error was not logged.
- Adds a new Refresh function, which allows control of the whole operation by passing the given Context all the way down the execution tree.
- Restricts the newly downloaded config JSON processing to only `200 OK` HTTP response status codes and valid response payloads. This way, the SDK won't overwrite the cache if it receives a syntactically valid but actually invalid config JSON payload, such as `{}`, `null`, or an empty string.

### Security (only if applicable)
- n/a

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
